### PR TITLE
Fix #58

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,9 +13,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Security:
 
 
+## [v0.2.1.dev0]
+### Fixed:
+ - [fpavogt, 2022-01-21] Fix #58.
+
 ## [v0.2.0.dev1]
 ### Fixed:
- - [fpavogt, 2022-01-21] First pypi release ?
+ - [fpavogt, 2022-01-21] First pypi release.
 
 ## [v0.2.0.dev0]
 ### Added:

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,6 @@ setup(
 
     ],
 
+    # Let's make sure the parameter non-py files get included in the wheels on pypi.
+    include_package_data=True
 )

--- a/src/ampycloud/version.py
+++ b/src/ampycloud/version.py
@@ -9,4 +9,4 @@ Module contains: ampycloud version
 """
 
 #:str: the one-and-only place where the ampycloud version is set.
-VERSION = '0.2.0.dev1'
+VERSION = '0.2.1.dev0'


### PR DESCRIPTION
**Description:**

This PR fixes a bad typo in the `setup.py` that prevented non-py files from being included in the wheels on pypi.

**Error(s) fixed:**

Fixes #58.

**Checklists**:
- [x] New code includes dedicated tests.
- [x] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [x] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
