### PR TITLE
Make ampycloud thread-safe

### DIFF
--- a/.github/workflows/CI_pylinter.yml
+++ b/.github/workflows/CI_pylinter.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8']
+        python-version: ['3.10']
 
     steps:
       # Checkout our repository

--- a/.github/workflows/CI_pytest.yml
+++ b/.github/workflows/CI_pytest.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     # Checkout the repository

--- a/.github/workflows/CI_speed_check.yml
+++ b/.github/workflows/CI_speed_check.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2022 MeteoSwiss, created by F.P.A. Vogt; frederic.vogt@meteoswiss.ch
+
+name: CI_speed_check
+
+on:
+  pull_request:
+    branches: [ master, develop, develop_vof ]
+
+jobs:
+  speed_check:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10']
+
+    steps:
+      # Checkout our repository
+      - name: Checkout current repository
+        uses: actions/checkout@v2
+
+      # Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install any dependency we require
+      - name: Install dependancies
+        run: |
+          python -m pip install --upgrade pip
+        shell: bash
+
+      # Here, let's install our module to make sure all the dependencies specified in setup.py are
+      # also installed
+      - name: Install our module
+        run: pip install -e .[dev]
+        shell: bash
+
+      # Launch a home-made python script to check the speed
+      - name: Run the speed test
+        run: python .github/workflows/speed_check.py
+        shell: bash

--- a/.github/workflows/check_version.py
+++ b/.github/workflows/check_version.py
@@ -15,6 +15,7 @@ Created January 2022; F.P.A. Vogt; frederic.vogt@meteoswiss.ch
 import argparse
 from pkg_resources import parse_version
 
+
 def main():
     ''' The main function. '''
 
@@ -43,6 +44,7 @@ def main():
         return True
 
     raise Exception('Ouch ! Version was not increased ?!')
+
 
 if __name__ == '__main__':
 

--- a/.github/workflows/docs_check.py
+++ b/.github/workflows/docs_check.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Copyright (c) 2020-2021 MeteoSwiss, contributors listed in AUTHORS.
+Copyright (c) 2020-2022 MeteoSwiss, contributors listed in AUTHORS.
 
 Distributed under the terms of the 3-Clause BSD License.
 

--- a/.github/workflows/docs_check.py
+++ b/.github/workflows/docs_check.py
@@ -14,6 +14,7 @@ Created June 2020; F.P.A. Vogt; frederic.vogt@meteoswiss.ch
 
 import subprocess
 
+
 def main():
     ''' The one true function. '''
 
@@ -39,6 +40,7 @@ def main():
     print('Docs compiled ok. Logs follow.')
     for line in lines:
         print(line)
+
 
 if __name__ == '__main__':
 

--- a/.github/workflows/pylinter.py
+++ b/.github/workflows/pylinter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Copyright (c) 2020-2021 MeteoSwiss, created by F.P.A. Vogt; frederic.vogt@meteoswiss.ch
+Copyright (c) 2020-2022 MeteoSwiss, created by F.P.A. Vogt; frederic.vogt@meteoswiss.ch
 
 Distributed under the terms of the 3-Clause BSD License.
 

--- a/.github/workflows/pylinter.py
+++ b/.github/workflows/pylinter.py
@@ -22,6 +22,7 @@ import os
 import re
 from pylint import epylint as lint
 
+
 def main():
     ''' The main function. '''
 
@@ -58,7 +59,7 @@ def main():
         error_codes = ','.join(args.exclude)
         pylint_command = '--disable='+error_codes
 
-    else: # just run pylint without tweaks
+    else:  # just run pylint without tweaks
 
         pylint_command = ''
 
@@ -108,6 +109,7 @@ def main():
         if score < args.min_score:
             raise Exception('''Ouch! pylint final score of %.2f is smaller than the specified
                                threshold of %.2f !''' % (float(score), args.min_score))
+
 
 if __name__ == '__main__':
 

--- a/.github/workflows/speed_check.py
+++ b/.github/workflows/speed_check.py
@@ -23,7 +23,7 @@ def main():
     if (lim := mean + 3*std) >= 1:
         raise Exception('Ouch ! ampycloud speed check failed: mean + 3*std >= 1s ...')
 
-    print(f'Speed check passed: mean + 3*std = {lim} s.')
+    print(f'Speed check passed: mean + 3*std = {lim:.2f} s.')
 
 if __name__ == '__main__':
 

--- a/.github/workflows/speed_check.py
+++ b/.github/workflows/speed_check.py
@@ -20,7 +20,7 @@ def main():
     (_, mean, std, _, _, _) = get_speed_benchmark()
 
     # Make sure that we remain below 1s at the 3 sigma level
-    if lim := (mean + 3*std) >= 1:
+    if (lim := mean + 3*std) >= 1:
         raise Exception('Ouch ! ampycloud speed check failed: mean + 3*std >= 1s ...')
 
     print(f'Speed check passed: mean + 3*std = {lim} s.')

--- a/.github/workflows/speed_check.py
+++ b/.github/workflows/speed_check.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+'''
+Copyright (c) 2022 MeteoSwiss, contributors listed in AUTHORS.
+
+Distributed under the terms of the 3-Clause BSD License.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+This script can be used together with a Github Action to check the speed of ampycloud is ok.
+
+Created February 2022; F.P.A. Vogt; frederic.vogt@meteoswiss.ch
+'''
+
+from ampycloud.utils.performance import get_speed_benchmark
+
+def main():
+    ''' The one true function. '''
+
+    # Run the default speed check
+    (_, mean, std, _, _, _) = get_speed_benchmark()
+
+    # Make sure that we remain below 1s at the 3 sigma level
+    if lim := (mean + 3*std) >= 1:
+        raise Exception('Ouch ! ampycloud speed check failed: mean + 3*std >= 1s ...')
+
+    print(f'Speed check passed: mean + 3*std = {lim} s.')
+
+if __name__ == '__main__':
+
+    main()

--- a/.github/workflows/speed_check.py
+++ b/.github/workflows/speed_check.py
@@ -13,6 +13,7 @@ Created February 2022; F.P.A. Vogt; frederic.vogt@meteoswiss.ch
 
 from ampycloud.utils.performance import get_speed_benchmark
 
+
 def main():
     ''' The one true function. '''
 
@@ -24,6 +25,7 @@ def main():
         raise Exception('Ouch ! ampycloud speed check failed: mean + 3*std >= 1s ...')
 
     print(f'Speed check passed: mean + 3*std = {lim:.2f} s.')
+
 
 if __name__ == '__main__':
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,4 +10,4 @@
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=a, ax, b, c, dt, fn, i, j, k, _, w, x, y, z
+good-names=_, a, ax, b, c, dt, f, fn, i, j, k, w, x, y, z

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [v0.4.0.dev0]
 ### Added:
+ - [fpavogt, 2022-02-27] Add new speed-check Action.
  - [fpavogt, 2022-02-25] Add the `prms` keyword to set parameters for each run call in a thread-safe manner.
 ### Fixed:
  - [fpavogt, 2022-02-25] Fix #71 and #25.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
  - [fpavogt, 2022-02-27] Add new speed-check Action.
  - [fpavogt, 2022-02-25] Add the `prms` keyword to set parameters for each run call in a thread-safe manner.
 ### Fixed:
+ - [fpavogt, 2022-03-02] Fix #75.
  - [fpavogt, 2022-02-25] Fix #71 and #25.
 ### Changed:
 ### Deprecated:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,17 @@ The format is inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.4.0.dev0]
+### Added:
+ - [fpavogt, 2022-02-25] Add the `prms` keyword to set parameters for each run call in a thread-safe manner.
+### Fixed:
+ - [fpavogt, 2022-02-25] Fix #71 and #25.
+### Changed:
+### Deprecated:
+### Removed:
+ - [fpavogt, 2022-02-25] Remove yaconfigobject dependency in favor of ruamel.yaml.
+### Security:
+
 ## [v0.3.0.dev0]
 ### Added:
  - [fpavogt, 2022-01-27] Add tests for the .plots.secondary module.
@@ -12,9 +23,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
  - [fpavogt, 2022-01-26] Fix #62, #63 and #64.
 ### Changed:
  - [fpavogt, 2022-02-01] Implement review feedback, including name change for `scaled` to `apply_scaling`.
-### Deprecated:
-### Removed:
-### Security:
 
 ## [v0.2.1.dev0]
 ### Fixed:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ def some_plot_function(...):
 ```
 :warning: Note how the `@set_mplstyle` decorator goes above the `@log_func_call()` decorator.
 
-With this decorator, all functions will automatically deploy the effects associated to the value of `dynamic.AMPYCLOUD_PRMS.MPL_STYLE` which can take one of the following values:
+With this decorator, all functions will automatically deploy the effects associated to the value of `dynamic.AMPYCLOUD_PRMS['MPL_STYLE']` which can take one of the following values:
 `['base', 'latex', 'metsymb']`.
 
 ### Release mechanisms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,6 @@ upon a new release or pre-release being published. See the ampycloud
   often how well you are doing using the command `pylint some_modified_file.py`.
 
 
-
 ### Logging
 
   No handlers/formatters are being defined in ampycloud, with the exception of a `NullHandler()` for
@@ -113,7 +112,7 @@ upon a new release or pre-release being published. See the ampycloud
 
     ```
     import logging
-    logger = loggging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
     ```
   * log calls are then simply done via this module logger:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,7 @@ Please be sure to read (and understand the implications) of the
 
 ## Essential things to know about ampycloud for dev work
 
-For now, ampycloud is being developed in a **private** repository under the [MeteoSwiss organization](https://github.com/MeteoSwiss/ampycloud) on Github. The documentation, generated using Sphinx, is hosted as Github Pages on the `gh-pages` branch of the repo, and is **publicly** visible
-at https://MeteoSwiss.github.io/ampycloud.
+ampycloud is being developed in a **public** repository under the [MeteoSwiss organization](https://github.com/MeteoSwiss/ampycloud) on Github. The documentation, generated using Sphinx, is hosted as Github Pages on the `gh-pages` branch of the repo, and is visible at https://MeteoSwiss.github.io/ampycloud.
 
 
 ### Branching model
@@ -68,7 +67,7 @@ pip install -e .[dev]
 ```
 Note the use of `[dev]` to also install the dependencies required for dev work (i.e. `sphinx`, `pylint`, etc ...).
 
-:warning: If you encouter the error `zsh: no matches found: .[dev]`, add some quotes as follows:
+:warning: If you encounter the error `zsh: no matches found: .[dev]`, add some quotes as follows:
 ```
 pip install -e '.[dev]'
 ```
@@ -81,6 +80,7 @@ Automated CI/CD checks are triggered upon Pull Requests being issued towards the
 
 * code linting using `pylint`
 * code testing using `pytest`
+* check that the base computational speed is ok
 * check that the CHANGELOG was updated
 * check that the Sphinx docs compile
 * automatic publication of the Sphinx docs (for a PR to `master` only)

--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ def mpls(request):
         def test_some_func(a, b, mpls):
             ...
             if mpls:
-                dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+                dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
     """
 

--- a/docs/source/examples/ampycloud_canonical_demo.py
+++ b/docs/source/examples/ampycloud_canonical_demo.py
@@ -16,7 +16,7 @@ import ampycloud.plots as ampyplots
 
 
 # Adjust the ampycloud scientific parameters
-dynamic.AMPYCLOUD_PRMS.MSA = 10000
+dynamic.AMPYCLOUD_PRMS['MSA'] = 10000
 
 # Generate and process the mock data
 mock_data, chunk = ampycloud.demo()

--- a/docs/source/examples/ampycloud_canonical_demo.py
+++ b/docs/source/examples/ampycloud_canonical_demo.py
@@ -22,6 +22,7 @@ dynamic.AMPYCLOUD_PRMS['MSA'] = 10000
 mock_data, chunk = ampycloud.demo()
 
 # Plot it
-ampyplots.diagnostic(chunk, upto='layers', show=False, save_fmts=['png'], ref_metar='FEW008 BKN037',
+ampyplots.diagnostic(chunk, upto='layers', show=False, save_fmts=['png'],
+                     ref_metar='FEW009 SCT018 BKN038',
                      ref_metar_origin='Mock data',
                      save_stem=Path(__file__).parent / 'ampycloud_canonical_mock_demo')

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,8 +38,8 @@ Welcome to the ampycloud documentation
   See also the code's :ref:`license & copyright <license:License & Copyright>` information.
 
 * **How:** a scientific article describing the ampycloud **algorithm** is currently in preparation.
-  This article will be complemented by these webpages that contain the official documentation of the
-  ampycloud **Python package**.
+  This article will be complemented by these webpages, that contain the official documentation of
+  the ampycloud **Python package**.
 
 Scope of ampycloud
 ------------------

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -99,14 +99,14 @@ Adjusting the default algorithm parameters
 
 The ampycloud parameters with a **scientific** impact on the outcome of the algorithm
 (see :ref:`here for the complete list <parameters:The ampycloud scientific parameters>`)
-are accessible via :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` as a nested dictionnary. When a new
+are accessible via :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` as a nested dictionary. When a new
 :py:class:`ampycloud.data.CeiloChunk` instance is being initiated, a copy of this nested dictionary
-is being stored as an instance variable (possibly adjusting specific parameters via the ``prms``
-keyword argument).
+is being stored as an instance variable. It is then possible to adjust specific parameters via the
+``prms`` keyword argument when initializing a :py:class:`ampycloud.data.CeiloChunk` instance.
 
 There are thus 2+1 ways to adjust the ampycloud scientific parameters:
 
-    * **1.a: Adjust them globally** in :py:data:`ampycloud.dynamic.AMPYCOUD_PRMS`, like so:
+    * **1.a: Adjust them globally** in :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS`, like so:
       ::
 
           from ampycloud import dynamic
@@ -126,10 +126,12 @@ There are thus 2+1 ways to adjust the ampycloud scientific parameters:
       copy of the default ampycloud parameters.
 
 
-    * **2: Adjust them for locally** for every execution of ampycloud by feeding a suitable nested
-      dictionary to :py:func:`ampycloud.core.run`. The dictionnary, the keys and levels of which
-      should be consistent with :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS`, only need to contains
-      the specific parameters that one requires to be different from the default values.
+    * **2: Adjust them for locally** for a given execution of ampycloud by feeding a suitable
+      nested dictionary to :py:func:`ampycloud.core.run` (that will create a new
+      :py:class:`ampycloud.data.CeiloChunk` instance behind the scene). The dictionary, the keys
+      and levels of which should be consistent with :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS`,
+      only needs to contain the specific parameters that one requires to be different from the
+      default values.
       ::
 
           # Define only the parameters that are non-default. To adjust the MSA, use:

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -19,8 +19,9 @@ A no-words example for those that want to get started quickly
     # Your data should have *exactly* this structure
     mock_data = mocker.canonical_demo_data()
 
-    # Run the ampycloud algorithm on it
-    chunk = ampycloud.run(mock_data, geoloc='Mock data', ref_dt=datetime.now())
+    # Run the ampycloud algorithm on it, setting the MSA to 10'000 ft
+    chunk = ampycloud.run(mock_data, prms={'MSA': 10000},
+                          geoloc='Mock data', ref_dt=datetime.now())
 
     # Get the resulting METAR message
     print(chunk.metar_msg())
@@ -96,35 +97,58 @@ only seek the outcome of the ampycloud algorithm formatted as a METAR-like ``str
 Adjusting the default algorithm parameters
 ..........................................
 
-.. important::
-
-    It is highly recommended to adjust any scientific parameters **before** executing any of the
-    ampycloud routines. Doing otherwise may have un-expected consequences (i.e. parameters may not
-    have the expected value). You have been warned.
-
 The ampycloud parameters with a **scientific** impact on the outcome of the algorithm
 (see :ref:`here for the complete list <parameters:The ampycloud scientific parameters>`)
-are accessible in the :py:mod:`ampycloud.dynamic` module.  From there, users can easily adjust them
-as they see fit. For example:
-::
+are accessible via :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` as a nested dictionnary. When a new
+:py:class:`ampycloud.data.CeiloChunk` instance is being initiated, a copy of this nested dictionary
+is being stored as an instance variable (possibly adjusting specific parameters via the ``prms``
+keyword argument).
 
-    from ampycloud import dynamic
+There are thus 2+1 ways to adjust the ampycloud scientific parameters:
 
-    dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'] = 95
+    * **1.a: Adjust them globally** in :py:data:`ampycloud.dynamic.AMPYCOUD_PRMS`, like so:
+      ::
 
-Note that it is important to always import the entire :py:mod:`ampycloud.dynamic` module and stick to the
-above structure if the updated parameters are to be *seen* by all the ampycloud modules.
+          from ampycloud import dynamic
 
-Alternatively, all the scientific parameters can be adjusted and fed to ampycloud via a YAML file,
-in which case the following routines, also accessible as ``ampycloud.copy_prm_file()`` and
-``ampycloud.set_prms()``, may be of interest:
-
-.. autofunction:: ampycloud.core.copy_prm_file
-    :noindex:
+          dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'] = 95
 
 
-.. autofunction:: ampycloud.core.set_prms
-    :noindex:
+      .. important::
+
+          Always import the entire :py:mod:`ampycloud.dynamic` module and stick to the
+          above example structure, if the updated parameters are to be *seen* by all the ampycloud
+          modules.
+
+
+    * **1.b: Adjust them globally** via a YAML file, and :py:func:`ampycloud.core.set_prms`. With
+      this approach, :py:func:`ampycloud.core.copy_prm_file()` can be used to obtain a local
+      copy of the default ampycloud parameters.
+
+
+    * **2: Adjust them for locally** for every execution of ampycloud by feeding a suitable nested
+      dictionary to :py:func:`ampycloud.core.run`. The dictionnary, the keys and levels of which
+      should be consistent with :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS`, only need to contains
+      the specific parameters that one requires to be different from the default values.
+      ::
+
+          # Define only the parameters that are non-default. To adjust the MSA, use:
+          my_prms = {'MSA': 10000}
+
+          # Or to adjust both the MSA and some other algorithm parameter:
+          my_prms = {'MSA': 10000, 'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 300}}}
+
+          # Then feed them directly to the run call
+          chunk = ampycloud.run(some_data_tbd, prms=my_prms)
+
+
+.. warning::
+
+    Options 1a and 1b are **not** thread-safe. Users planning to launch multiple ampycloud
+    processes simultaneously are urged to use option 2, if they need to set distinct parameters
+    between each. In case of doubts, the parameters used by a given
+    :py:class:`ampycloud.data.CeiloChunk` instance is accessible via the (parent)
+    :py:meth:`ampycloud.data.AbstractChunk.prms` property.
 
 
 If all hope is lost and you wish to revert to the original (default) values of all the
@@ -132,30 +156,6 @@ ampycloud scientific parameters, you can use :py:func:`ampycloud.core.reset_prms
 
 .. autofunction:: ampycloud.core.reset_prms
     :noindex:
-
-
-Advanced info for advanced users
-********************************
-
-The majority of parameters present in :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` are fetched
-directly by the methods of the :py:class:`ampycloud.data.CeiloChunk` class when they are required.
-As a result, modifying a specific entry in :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` (e.g.
-``OKTA_LIM8``) will be seen by any :py:class:`ampycloud.data.CeiloChunk` instance already in
-existence.
-
-The ``MSA`` and ``MSA_HIT_BUFFER`` entries are the only exception to this rule ! These two
-parameters are being applied (and deep-copied as :py:class:`ampycloud.data.CeiloChunk` instance
-attributes) immediately at the initialization of any :py:class:`ampycloud.data.CeiloChunk` instance.
-This implies that:
-
-    1. any cloud hits above ``MSA + MSA_HIT_BUFFER`` in the data will be cropped immediately in the
-       :py:meth:`ampycloud.data.CeiloChunk.__init__` routine, and thus cannot be recovered by
-       subsequently changing the value of ``MSA`` in :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS`,
-       and
-    2. any METAR-like message issued will always be subject to the Minimum Sector Altitude
-       value that was specified in :py:data:`ampycloud.dynamic.AMPYCLOUD_PRMS` at the time the
-       :py:class:`ampycloud.data.CeiloChunk` instance was initialized. This is to ensure
-       consistency with the cropped data at all times.
 
 .. _logging:
 

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -110,7 +110,7 @@ as they see fit. For example:
 
     from ampycloud import dynamic
 
-    dynamic.AMPYCLOUD_PRMS.OKTA_LIM8 = 95
+    dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'] = 95
 
 Note that it is important to always import the entire :py:mod:`ampycloud.dynamic` module and stick to the
 above structure if the updated parameters are to be *seen* by all the ampycloud modules.
@@ -208,7 +208,7 @@ the appropriate ampycloud parameter:
 ::
 
     from ampycloud import dynamic
-    dynamic.AMPYCLOUD_PRMS.MPL_STYLE = 'latex'
+    dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = 'latex'
 
 And for the most demanding users that want nothing but the best, they can create plots with actual
 okta symbols if they install the `metsymb LaTeX package <https://github.com/MeteoSwiss/metsymb>`__
@@ -216,7 +216,7 @@ system-wide, and set:
 ::
 
     from ampycloud import dynamic
-    dynamic.AMPYCLOUD_PRMS.MPL_STYLE = 'metsymb'
+    dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = 'metsymb'
 
 
 .. important::

--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -19,7 +19,7 @@ This has the following implications for ampycloud:
         - improve the usability of ampycloud without altering the quality of the results, and/or
         - demonstrate a significant improvement in the quality of the results.
 
-    * The ingestion of external contributions may be delayed to allow for careful, internal
+    * The ingestion of external contributions may be delayed to allow for a careful, internal
       verification that they do not affect the MeteoSwiss operational chain that relies on
       ampycloud.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "scikit-learn >= 0.24.2",
         "pandas >= 1.3.1",
         "pyyaml",
-        "yaconfigobject"
+        "ruamel.yaml"
     ],
     extras_require={
         'dev': ['sphinx', 'sphinx-rtd-theme', 'pylint', 'pytest']

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
 
     # Include all packages under src
     packages=find_packages(where="src"),
-
     # Tell setuptools packages are under src
     package_dir={"": "src"},
 
@@ -53,33 +52,25 @@ setup(
     extras_require={
         'dev': ['sphinx', 'sphinx-rtd-theme', 'pylint', 'pytest']
     },
-
     # Setup entry points to use ampycloud directly from a terminal
-    entry_points={'console_scripts':
-        ['ampycloud_speed_test=ampycloud.__main__:ampycloud_speed_test',
-         'ampycloud_copy_prm_file=ampycloud.__main__:ampycloud_copy_prm_file']},
-
+    entry_points={
+        'console_scripts': ['ampycloud_speed_test=ampycloud.__main__:ampycloud_speed_test',
+                            'ampycloud_copy_prm_file=ampycloud.__main__:ampycloud_copy_prm_file']},
     classifiers=[
-
         # How mature is this project? Common values are
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
         'Development Status :: 3 - Alpha',
-
         # Indicate who your project is intended for
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Atmospheric Science',
-
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: BSD License',
-
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.8',
-
     ],
-
     # Let's make sure the parameter non-py files get included in the wheels on pypi.
     include_package_data=True
 )

--- a/src/ampycloud/__init__.py
+++ b/src/ampycloud/__init__.py
@@ -13,7 +13,7 @@ import logging
 
 # Import from this package
 from . import version as vers
-from .core import * # Bring out the core routines for easy access by the user
+from .core import *  # Bring out the core routines for easy access by the user
 
 # Instantiate the module logger
 logger = logging.getLogger(__name__)

--- a/src/ampycloud/__main__.py
+++ b/src/ampycloud/__main__.py
@@ -18,13 +18,15 @@ from .version import VERSION
 from .utils import performance
 from .core import copy_prm_file
 
+
 def ampycloud_speed_test() -> None:
     """ The ampycloud_speed_test entry point, meant to by launched from the command line. """
 
     # Use argparse to make ampycloud user friendly
-    parser = argparse.ArgumentParser(description=
-        'ampycloud {}'.format(VERSION) + ' - Python package to characterize cloud layers' +
-        ' using ceilometer measurements.\n'+
+    parser = argparse.ArgumentParser(
+        description='ampycloud {}'.format(VERSION) +
+        ' - Python package to characterize cloud layers' +
+        ' using ceilometer measurements.\n' +
         'This entry point lets you measure the performance of ampycloud on your machine.',
         epilog='For details: https://MeteoSwiss.github.io/ampycloud\n ',
         formatter_class=argparse.RawTextHelpFormatter)
@@ -46,16 +48,18 @@ def ampycloud_speed_test() -> None:
     print(' * mean [std]: %.2fs [%.2fs]' % (mean, std))
     print(' * median [min; max]: %.2fs [%.2fs; %.2fs]\n' % (median, mmin, mmax))
 
+
 def ampycloud_copy_prm_file() -> None:
     """ The ampycloud_copy_prm_file entry point, meant to be launched from the command line. """
 
     # Use argparse to make ampycloud user friendly
-    parser = argparse.ArgumentParser(description=
-        'ampycloud {}'.format(VERSION) + ' - Python package to characterize cloud layers' +
-            ' using ceilometer measurements.\n'+
-            'This entry point lets you get a local copy the ampycloud parameter files.',
-            epilog='For details: https://MeteoSwiss.github.io/ampycloud\n ',
-            formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description='ampycloud {}'.format(VERSION) +
+        ' - Python package to characterize cloud layers' +
+        ' using ceilometer measurements.\n' +
+        'This entry point lets you get a local copy the ampycloud parameter files.',
+        epilog='For details: https://MeteoSwiss.github.io/ampycloud\n ',
+        formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('-which', action='store', default='default', type=str,
                         metavar='name',

--- a/src/ampycloud/__main__.py
+++ b/src/ampycloud/__main__.py
@@ -11,6 +11,7 @@ Module contains: high-level entry point routines
 # Import from Python
 import argparse
 import platform
+import multiprocessing as mp
 from datetime import datetime
 
 # Import from ampycloud
@@ -43,7 +44,9 @@ def ampycloud_speed_test() -> None:
     niter, mean, std, median, mmin, mmax = performance.get_speed_benchmark(niter=args.niter)
 
     print('\nTest datetime: %s' % (datetime.now()))
-    print('Platform: %s\n' % (platform.platform()))
+    print('Platform: %s' % (platform.platform()))
+    print('CPU count: %i\n' % (mp.cpu_count()))
+
     print('ampycloud.demo() execution time from %i runs:' % niter)
     print(' * mean [std]: %.2fs [%.2fs]' % (mean, std))
     print(' * median [min; max]: %.2fs [%.2fs; %.2fs]\n' % (median, mmin, mmax))

--- a/src/ampycloud/cluster.py
+++ b/src/ampycloud/cluster.py
@@ -21,10 +21,11 @@ from .logger import log_func_call
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def agglomerative_cluster(data : np.ndarray, n_clusters : int = None,
-                          affinity : str = 'euclidean', linkage : str = 'single',
-                          distance_threshold : Union[int, float] = 1) -> tuple:
+def agglomerative_cluster(data: np.ndarray, n_clusters: int = None,
+                          affinity: str = 'euclidean', linkage: str = 'single',
+                          distance_threshold: Union[int, float] = 1) -> tuple:
     """ Function that wraps arround :py:class:`sklearn.cluster.AgglomerativeClustering`.
 
     Args:
@@ -51,8 +52,9 @@ def agglomerative_cluster(data : np.ndarray, n_clusters : int = None,
     # Return the stuff of interest
     return agg_clu.n_clusters_, agg_clu.labels_
 
+
 @log_func_call(logger)
-def clusterize(data : np.ndarray, algo : str = None, **kwargs : dict) -> tuple:
+def clusterize(data: np.ndarray, algo: str = None, **kwargs: dict) -> tuple:
     """ Umbrella clustering routine, that provides a single access point to the different clustering
     algorithms.
 

--- a/src/ampycloud/core.py
+++ b/src/ampycloud/core.py
@@ -198,7 +198,7 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
     Alternatively, the scientific parameters can also be defined and fed to ampycloud via a YAML
     file. See :py:func:`.set_prms()` for details.
 
-    .. warning:
+    Caution:
         By default, the function :py:func:`.run` will use the parameter values set in
         :py:data:`dynamic.AMPYCLOUD_PRMS`, which is not thread safe. Users interested to run
         **multiple concurrent ampycloud calculations with distinct sets of parameters within the
@@ -208,6 +208,7 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
 
         Examples:
         ::
+
             # Define only the parameters that are non-default. To adjust the MSA, use:
             prms = {'MSA': 10000}
 
@@ -235,7 +236,8 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
             mock_data = mocker.canonical_demo_data()
 
             # Run the ampycloud algorithm on it, setting the MSA to 10'000 ft
-            chunk = ampycloud.run(mock_data, geoloc='Mock data', ref_dt=datetime.now())
+            chunk = ampycloud.run(mock_data, prms={'MSA':10000},
+                                  geoloc='Mock data', ref_dt=datetime.now())
 
             # Get the resulting METAR message
             print(chunk.metar_msg())

--- a/src/ampycloud/core.py
+++ b/src/ampycloud/core.py
@@ -250,6 +250,10 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
     starttime = datetime.now()
     logger.info('Starting an ampycloud run at %s', starttime)
 
+    # If the user gave me a datetime, convert this to str before proceeding
+    if not isinstance(ref_dt, str) and ref_dt is not None:
+        ref_dt = str(ref_dt)
+
     # First, let's create an CeiloChunk instance ...
     chunk = CeiloChunk(data, prms=prms, geoloc=geoloc, ref_dt=ref_dt)
 

--- a/src/ampycloud/core.py
+++ b/src/ampycloud/core.py
@@ -17,12 +17,13 @@ from pathlib import Path
 from shutil import copy
 from datetime import datetime
 import pandas as pd
-from yaconfigobject import Config
+from ruamel.yaml import YAML
 
 # Import from ampycloud
 from .errors import AmpycloudError, AmpycloudWarning
 from .logger import log_func_call
 from .utils.mocker import canonical_demo_data
+from .utils import utils
 from .data import CeiloChunk
 from . import dynamic
 
@@ -77,7 +78,6 @@ def copy_prm_file(save_loc : str = './', which : str = 'defaults') -> None:
     # All looks good, let's copy the file
     copy(ref_loc / fname, save_loc / fname)
 
-
 @log_func_call(logger)
 def set_prms(pth : Union[str, Path]) -> None:
     """ Sets the dynamic=scientific ampycloud parameters from a suitable YAML file.
@@ -87,10 +87,14 @@ def set_prms(pth : Union[str, Path]) -> None:
 
     .. note::
         It is recommended to first get a copy of the default ampycloud parameter file
-        using :py:func:`.copy_prm_file()`, and edit its content as required.
+        using :py:func:`.copy_prm_file`, and edit its content as required.
 
         Doing so should ensure full compliance with the default structure of
         :py:data:`.dynamic.AMPYCLOUD_PRMS`.
+
+    .. warning::
+        This is NOT a thread-safe way of setting parameters. If you plan on running concurrent
+        ampycloud evaluations, parameters should be fed directly to :py:func:`.run`.
 
     Example:
         ::
@@ -116,23 +120,12 @@ def set_prms(pth : Union[str, Path]) -> None:
                       ' Are you sure this is ok ?', AmpycloudWarning)
 
     # Extract all the parameters
-    with open(pth) as fil:
-        logger.info('Opening (user) parameter file: %s', fil)
-        user_prms = Config(paths=[str(fil.parent)], name=str(fil.name))
+    logger.info('Opening (user) parameter file: %s', pth)
+    yaml=YAML(typ='safe')
+    user_prms = yaml.load(pth)
 
-    # Now, assign the prms
-    for (key, item) in user_prms.items():
-        if not isinstance(item, dict):
-            logger.info('Setting %s ...', key)
-            logger.debug('... with value: %s', item)
-            dynamic.AMPYCLOUD_PRMS.key = item
-
-        else:
-            for (subkey, subitem) in item.items():
-                logger.info('Setting %s.%s ...', key, subkey)
-                logger.debug('... with value: %s', subitem)
-                dynamic.AMPYCLOUD_PRMS.key.subkey = subitem
-
+    # Now, assign the new prms
+    dynamic.AMPYCLOUD_PRMS = utils.adjust_nested_dict(dynamic.AMPYCLOUD_PRMS, user_prms)
 
 @log_func_call(logger)
 def reset_prms() -> None:
@@ -145,22 +138,25 @@ def reset_prms() -> None:
             from ampycloud import dynamic
 
             # Change a parameter
-            dynamic.AMPYCLOUD_PRMS.OKTA_LIM8 = 95
+            dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'] = 95
             # Reset them
             ampycloud.reset_prms()
-            print('Back to the default value:', dynamic.AMPYCLOUD_PRMS.OKTA_LIM8)
+            print('Back to the default value:', dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'])
 
     """
 
     dynamic.AMPYCLOUD_PRMS = dynamic.get_default_prms()
 
 @log_func_call(logger)
-def run(data : pd.DataFrame, geoloc : str = None,
+def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
         ref_dt : Union[str, datetime] = None) -> CeiloChunk:
     """ Runs the ampycloud algorithm on a given dataset.
 
     Args:
         data (pd.DataFrame): the data to be processed, as a :py:class:`pandas.DataFrame`.
+        prms (dict, optional): a (nested) dict of parameters to adjust for this specific run.
+            This is meant as a thread-safe way of adjusting parameters for different runs. Any
+            unspecified parameter will be taken from :py:data:`dynamic.AMPYCLOUD_PRMS` at init time.
         geoloc (str, optional): the name of the geographic location where the data was taken.
             Defaults to None.
         ref_dt (str|datetime.datetime, optional): reference date and time of the observations,
@@ -197,10 +193,27 @@ def run(data : pd.DataFrame, geoloc : str = None,
     ::
 
         from ampycloud import dynamic
-        dynamic.AMPYCLOUD_PRMS.MSA = 5000
+        dynamic.AMPYCLOUD_PRMS['MSA'] = 5000
 
-    Alternatively, all the scientific parameters can also be defined and fed to ampycloud via a YAML
+    Alternatively, the scientific parameters can also be defined and fed to ampycloud via a YAML
     file. See :py:func:`.set_prms()` for details.
+
+    .. warning:
+        By default, the function :py:func:`.run` will use the parameter values set in
+        :py:data:`dynamic.AMPYCLOUD_PRMS`, which is not thread safe. Users interested to run
+        **multiple concurrent ampycloud calculations with distinct sets of parameters within the
+        same Python session** are thus urged to feed the required parameters directly to
+        :py:func:`.run()` via the ``prms`` keyword argument, which expects a (nested) dictionnary
+        with keys compatible with :py:data:`dynamic.AMPYCLOUD_PRMS`.
+
+        Examples:
+        ::
+            # Define only the parameters that are non-default. To adjust the MSA, use:
+            prms = {'MSA': 10000}
+
+            # Or to adjust some other algorithm parameter:
+            prms = {'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 300}}}
+
 
     The :py:class:`.data.CeiloChunk` instance returned by this function contains all the information
     associated to the ampycloud algorithm, inclduing the raw data and slicing/grouping/layering
@@ -221,7 +234,7 @@ def run(data : pd.DataFrame, geoloc : str = None,
             # Generate the canonical demo dataset for ampycloud
             mock_data = mocker.canonical_demo_data()
 
-            # Run the ampycloud algorithm on it
+            # Run the ampycloud algorithm on it, setting the MSA to 10'000 ft
             chunk = ampycloud.run(mock_data, geoloc='Mock data', ref_dt=datetime.now())
 
             # Get the resulting METAR message
@@ -236,7 +249,7 @@ def run(data : pd.DataFrame, geoloc : str = None,
     logger.info('Starting an ampycloud run at %s', starttime)
 
     # First, let's create an CeiloChunk instance ...
-    chunk = CeiloChunk(data, geoloc = geoloc, ref_dt = str(ref_dt))
+    chunk = CeiloChunk(data, prms=prms, geoloc=geoloc, ref_dt=ref_dt)
 
     # Go through the ampycloud cascade:
     # Run the slicing ...

--- a/src/ampycloud/core.py
+++ b/src/ampycloud/core.py
@@ -30,8 +30,9 @@ from . import dynamic
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def copy_prm_file(save_loc : str = './', which : str = 'defaults') -> None:
+def copy_prm_file(save_loc: str = './', which: str = 'defaults') -> None:
     """ Create a local copy of a specific ampycloud parameter file.
 
     Args:
@@ -78,8 +79,9 @@ def copy_prm_file(save_loc : str = './', which : str = 'defaults') -> None:
     # All looks good, let's copy the file
     copy(ref_loc / fname, save_loc / fname)
 
+
 @log_func_call(logger)
-def set_prms(pth : Union[str, Path]) -> None:
+def set_prms(pth: Union[str, Path]) -> None:
     """ Sets the dynamic=scientific ampycloud parameters from a suitable YAML file.
 
     Args:
@@ -116,16 +118,17 @@ def set_prms(pth : Union[str, Path]) -> None:
     if not pth.is_file():
         raise AmpycloudError(f'Ouch ! {pth} is not a file !')
     if (suf := pth.suffix) != '.yml':
-        warnings.warn(f'Hum ... I was expecting a .yml file, but got {suf} instead.'+
+        warnings.warn(f'Hum ... I was expecting a .yml file, but got {suf} instead.' +
                       ' Are you sure this is ok ?', AmpycloudWarning)
 
     # Extract all the parameters
     logger.info('Opening (user) parameter file: %s', pth)
-    yaml=YAML(typ='safe')
+    yaml = YAML(typ='safe')
     user_prms = yaml.load(pth)
 
     # Now, assign the new prms
     dynamic.AMPYCLOUD_PRMS = utils.adjust_nested_dict(dynamic.AMPYCLOUD_PRMS, user_prms)
+
 
 @log_func_call(logger)
 def reset_prms() -> None:
@@ -147,9 +150,10 @@ def reset_prms() -> None:
 
     dynamic.AMPYCLOUD_PRMS = dynamic.get_default_prms()
 
+
 @log_func_call(logger)
-def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
-        ref_dt : Union[str, datetime] = None) -> CeiloChunk:
+def run(data: pd.DataFrame, prms: dict = None, geoloc: str = None,
+        ref_dt: Union[str, datetime] = None) -> CeiloChunk:
     """ Runs the ampycloud algorithm on a given dataset.
 
     Args:
@@ -167,8 +171,8 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
         :py:class:`.data.CeiloChunk`: the data chunk with all the processing outcome bundled
         cleanly.
 
-    All that is required to run the ampycloud algorithm is
-    `a properly formatted dataset <https://meteoswiss.github.io/ampycloud/running.html#the-input-data>`__.
+    All that is required to run the ampycloud algorithm is a properly
+    `formatted dataset <https://meteoswiss.github.io/ampycloud/running.html#the-input-data>`__.
     At the moment, specifying ``geoloc`` and ``ref_dt`` serves no purpose other than to enhance
     plots (should they be created). There is no special requirements for ``geoloc`` and ``ref_dt``:
     as long as they are strings, you can set them to whatever you please.
@@ -269,8 +273,9 @@ def run(data : pd.DataFrame, prms : dict = None, geoloc : str = None,
 
     return chunk
 
+
 @log_func_call(logger)
-def metar(data : pd.DataFrame) -> str:
+def metar(data: pd.DataFrame) -> str:
     """ Run the ampycloud algorithm on a dataset and extract a METAR report of the cloud layers.
 
     Args:
@@ -300,6 +305,7 @@ def metar(data : pd.DataFrame) -> str:
     # Then, return the METAR message
     return chunk.metar_msg(which='layers')
 
+
 @log_func_call(logger)
 def demo() -> tuple:
     """ Run the ampycloud algorithm on a demonstration dataset.
@@ -315,6 +321,6 @@ def demo() -> tuple:
     assert isinstance(mock_data, pd.DataFrame)
 
     # Run the ampycloud algorithm
-    chunk =  run(mock_data, geoloc='ampycloud demo', ref_dt = str(datetime.now()))
+    chunk = run(mock_data, geoloc='ampycloud demo', ref_dt=str(datetime.now()))
 
     return mock_data, chunk

--- a/src/ampycloud/data.py
+++ b/src/ampycloud/data.py
@@ -608,11 +608,11 @@ class CeiloChunk(AbstractChunk):
             # Only look for multiple layers if it is worth it ...
             # 1) Layer density is large enough
             cond1 = self.groups.at[ind, 'okta'] < self.prms['LAYERING_PRMS']['min_okta_to_split']
-            # 2) I have more than three valid points (since I will look for up to 3 components)
-            cond2 = len(gro_alts[~np.isnan(gro_alts)]) < 3
+            # 2) I have more than 30 valid points (GMM is unstable below this amount).
+            cond2 = len(gro_alts[~np.isnan(gro_alts)]) < 30
             if cond1 or cond2:
                 # Add some useful info to the log
-                logger.info('Skipping the layering because: MIN_OKTA [%s] | 3PT [%s]',
+                logger.info('Skipping the layering because: <min_okta_to_split [%s] | <30 pts [%s]',
                              cond1, cond2)
                 # Here, set ncomp to -1 to show clearly that I did NOT actually check it ...
                 self.groups.at[ind, 'ncomp'] = -1

--- a/src/ampycloud/data.py
+++ b/src/ampycloud/data.py
@@ -106,8 +106,7 @@ class AbstractChunk(ABC):
         return data
 
     @log_func_call(logger)
-    @staticmethod
-    def _setup_prms(prms: dict) -> dict:
+    def _setup_prms(self, prms: dict) -> dict:
         """ Setup a full dict of ampycloud prms given a user input, using default prms where
         necessary. """
 

--- a/src/ampycloud/data.py
+++ b/src/ampycloud/data.py
@@ -11,14 +11,13 @@ Module contains: data classes
 # Import from Python
 from typing import Union
 import logging
-import warnings
 import copy
 from abc import ABC, abstractmethod
 import numpy as np
 import pandas as pd
 
 # Import from this package
-from .errors import AmpycloudError, AmpycloudWarning
+from .errors import AmpycloudError
 from .logger import log_func_call
 from . import scaler, cluster, layer
 from . import wmo, icao

--- a/src/ampycloud/dynamic.py
+++ b/src/ampycloud/dynamic.py
@@ -10,13 +10,15 @@ Module contains: dynamic (scientific) parameters, which can be altered during ex
 
 # Import from Python
 from pathlib import Path
-from yaconfigobject import Config
+from ruamel.yaml import YAML
 
-def get_default_prms() -> Config:
+def get_default_prms() -> dict:
     """ Extract the default ampycloud parameters from the YAML configuration file. """
 
-    return Config(paths=[str(Path(__file__).parent/ 'prms')], name='ampycloud_default_prms.yml')
+    yaml=YAML(typ='safe')
+    out = yaml.load(Path(__file__).parent / 'prms' / 'ampycloud_default_prms.yml')
 
+    return out
 
 #:dict: The ampycloud parameters, first set from a config file via :py:func:`.get_default_prms`
 AMPYCLOUD_PRMS = get_default_prms()

--- a/src/ampycloud/dynamic.py
+++ b/src/ampycloud/dynamic.py
@@ -12,13 +12,15 @@ Module contains: dynamic (scientific) parameters, which can be altered during ex
 from pathlib import Path
 from ruamel.yaml import YAML
 
+
 def get_default_prms() -> dict:
     """ Extract the default ampycloud parameters from the YAML configuration file. """
 
-    yaml=YAML(typ='safe')
+    yaml = YAML(typ='safe')
     out = yaml.load(Path(__file__).parent / 'prms' / 'ampycloud_default_prms.yml')
 
     return out
 
-#:dict: The ampycloud parameters, first set from a config file via :py:func:`.get_default_prms`
+
+#: dict: The ampycloud parameters, first set from a config file via :py:func:`.get_default_prms`
 AMPYCLOUD_PRMS = get_default_prms()

--- a/src/ampycloud/errors.py
+++ b/src/ampycloud/errors.py
@@ -13,6 +13,7 @@ class AmpycloudError(Exception):
     """ The default error class for ampycloud, which is a child of the :py:exc:`Exception` class.
     """
 
+
 class AmpycloudWarning(Warning):
     """ The default warning class for ampycloud, which is a child of the :py:class:`Warning` class.
     """

--- a/src/ampycloud/icao.py
+++ b/src/ampycloud/icao.py
@@ -17,8 +17,9 @@ from .logger import log_func_call
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def significant_cloud(oktas : list) -> list:
+def significant_cloud(oktas: list) -> list:
     """ Assesses which cloud layers in a list are significant, according to the ICAO rules.
 
     Args:

--- a/src/ampycloud/layer.py
+++ b/src/ampycloud/layer.py
@@ -25,8 +25,9 @@ from .utils import utils
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def scores2nrl(abics : np.ndarray) -> np.ndarray:
+def scores2nrl(abics: np.ndarray) -> np.ndarray:
     """ Converts AIC or BIC scores into probabilities = normalized relative likelihood.
 
     Specifically, this function computes:
@@ -51,9 +52,10 @@ def scores2nrl(abics : np.ndarray) -> np.ndarray:
 
     return out
 
+
 @log_func_call(logger)
-def best_gmm(abics : np.ndarray, mode : str = 'delta',
-             min_prob : float = 1., delta_mul_gain : float = 1.) -> int:
+def best_gmm(abics: np.ndarray, mode: str = 'delta',
+             min_prob: float = 1., delta_mul_gain: float = 1.) -> int:
     """ Identify which Gaussian Mixture Model is most appropriate given AIC or BIC scores.
 
     Model selection can be based on:
@@ -107,7 +109,7 @@ def best_gmm(abics : np.ndarray, mode : str = 'delta',
     # Compute the relative probabilities of each model from the scores,
     # i.e. compute the "relative likelihood" of each model, normalized by the sum of all relative
     # likelihoods (if warranted)
-    if mode=='prob':
+    if mode == 'prob':
         nrl = scores2nrl(abics)
 
     # Now figure out if more than one components hides in the data.
@@ -134,13 +136,14 @@ def best_gmm(abics : np.ndarray, mode : str = 'delta',
 
     return best_model_ind
 
+
 @log_func_call(logger)
-def ncomp_from_gmm(vals : np.ndarray,
-                   min_sep : Union[int, float] = 0,
-                   scores : str = 'BIC',
-                   rescale_0_to_x : float = None,
-                   random_seed : int = 42,
-                   **kwargs : dict) -> tuple:
+def ncomp_from_gmm(vals: np.ndarray,
+                   min_sep: Union[int, float] = 0,
+                   scores: str = 'BIC',
+                   rescale_0_to_x: float = None,
+                   random_seed: int = 42,
+                   **kwargs: dict) -> tuple:
     """ Runs a Gaussian Mixture Model on 1-D data, to determine if it contains 1, 2, or 3
     components.
 
@@ -173,7 +176,6 @@ def ncomp_from_gmm(vals : np.ndarray,
         `<https://www.astroml.org/book_figures/chapter4/fig_GMM_1D.html>`_
     """
 
-
     # If I get a 1-D array, deal with it.
     if np.ndim(vals) == 1:
         vals = vals.reshape(-1, 1)
@@ -181,15 +183,20 @@ def ncomp_from_gmm(vals : np.ndarray,
     # Keep track of the original values
     vals_orig = copy.deepcopy(vals)
 
+    # If all the points are the same, I should not bother doing anything ...
+    if len(np.unique(vals_orig)) == 1:
+        logger.debug('Skipping the GMM computation: all the values are the same.')
+        return (1, np.zeros(len(vals_orig)), None)
+
     # Estimate the resolution of the data (by measuring the minimum separation between two data
     # points).
     res_orig = np.diff(np.sort(vals_orig.reshape(len(vals_orig))))
-    res_orig = np.min(res_orig[res_orig>0])
+    res_orig = np.min(res_orig[res_orig > 0])
     logger.debug('res_orig: %.2f', res_orig)
     # Is min_sep sufficiently large, given the data resolution ? If not, we we end up with some
     # over-layering.
     if min_sep < 5*res_orig:
-        warnings.warn(f'Huh ! min_sep={min_sep} is smaller than 5*res_orig={5*res_orig}.'+
+        warnings.warn(f'Huh ! min_sep={min_sep} is smaller than 5*res_orig={5*res_orig}.' +
                       'This could lead to an over-layering for thin groups !',
                       AmpycloudWarning)
 
@@ -231,7 +238,7 @@ def ncomp_from_gmm(vals : np.ndarray,
 
     # If I found more than one component, let's make sure that they are sufficiently far apart.
     # First, let's compute the mean component heights
-    mean_comp_heights = [np.mean(vals_orig[best_ids==i]) for i in range(ncomp[best_model_ind])]
+    mean_comp_heights = [np.mean(vals_orig[best_ids == i]) for i in range(ncomp[best_model_ind])]
 
     # These may not be ordered, so let's keep track of the indices
     # First, let's deal with the fact that they are not ordered.
@@ -247,7 +254,7 @@ def ncomp_from_gmm(vals : np.ndarray,
 
         # Else, I have two components that are "too close" from each other. Let's merge them by
         # re-assigning the ids accordingly.
-        best_ids[best_ids==comp_ids[ind+1]] = comp_ids[ind]
+        best_ids[best_ids == comp_ids[ind+1]] = comp_ids[ind]
         comp_ids[ind+1] = comp_ids[ind]
 
         # Decrease the number of valid ids

--- a/src/ampycloud/logger.py
+++ b/src/ampycloud/logger.py
@@ -14,7 +14,8 @@ import inspect
 from typing import Callable
 from functools import wraps
 
-def log_func_call(logger : logging.Logger) -> Callable:
+
+def log_func_call(logger: logging.Logger) -> Callable:
     """ Intended as a decorator to log function calls.
 
     The first part of the message containing the function name is at the 'INFO' level.
@@ -31,7 +32,7 @@ def log_func_call(logger : logging.Logger) -> Callable:
 
     """
 
-    def deco(func : Callable) -> Callable:
+    def deco(func: Callable) -> Callable:
         """ This is the actual function decorator. """
 
         @wraps(func)  # This black magic is required for Sphinx to still pickup the func docstrings.

--- a/src/ampycloud/plots/core.py
+++ b/src/ampycloud/plots/core.py
@@ -21,12 +21,13 @@ from .tools import set_mplstyle
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @set_mplstyle
 @log_func_call(logger)
-def diagnostic(chunk : CeiloChunk, upto : str = 'layers', show_ceilos : bool = False,
-               ref_metar : str = None, ref_metar_origin : str = None,
-               show : bool = True,
-               save_stem : str = None, save_fmts : Union[list, str] = None) -> None:
+def diagnostic(chunk: CeiloChunk, upto: str = 'layers', show_ceilos: bool = False,
+               ref_metar: str = None, ref_metar_origin: str = None,
+               show: bool = True,
+               save_stem: str = None, save_fmts: Union[list, str] = None) -> None:
     """ A function to create the ampycloud diagnostic plot all the way to the layering step
     (included). This is the ultimate ampycloud plot that shows it all (or not - you choose !).
 
@@ -79,7 +80,7 @@ def diagnostic(chunk : CeiloChunk, upto : str = 'layers', show_ceilos : bool = F
         adp.show_slices()
         adp.format_slice_axes()
     if upto in ['groups', 'layers']:
-        adp.show_groups(show_points= (upto=='groups'))
+        adp.show_groups(show_points=(upto == 'groups'))
         adp.format_group_axes()
     if upto == 'layers':
         adp.show_layers()

--- a/src/ampycloud/plots/diagnostics.py
+++ b/src/ampycloud/plots/diagnostics.py
@@ -194,7 +194,7 @@ class DiagnosticPlot:
             # Let's also plot the overlap area of the slice
             slice_mean = self._chunk.slices.loc[ind, 'alt_mean']
             slice_std = self._chunk.slices.loc[ind, 'alt_std']
-            overlap = dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.overlap
+            overlap = self._chunk.prms['GROUPING_PRMS']['overlap']
 
             # Get some fake data spanning the entire data range
             misc = np.linspace(np.nanmin(self._chunk.data['dt']),
@@ -222,7 +222,7 @@ class DiagnosticPlot:
 
             # Show the slice METAR text
             msg = r'\smaller ' + wmo.okta2symb(self._chunk.slices.iloc[ind]['okta'],
-                use_metsymb=(dynamic.AMPYCLOUD_PRMS.MPL_STYLE == 'metsymb')) +\
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
                 ' ' + self._chunk.slices.iloc[ind]['code'] + warn
             self._axs[1].text(0.5, self._chunk.slices.iloc[ind]['alt_base'],
                               texify(msg),
@@ -275,7 +275,7 @@ class DiagnosticPlot:
 
             # Show the group METAR text
             msg = r'\smaller ' + wmo.okta2symb(self._chunk.groups.iloc[ind]['okta'],
-                use_metsymb=(dynamic.AMPYCLOUD_PRMS.MPL_STYLE == 'metsymb')) +\
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
                 ' ' + self._chunk.groups.iloc[ind]['code'] + warn
             self._axs[2].text(0.5, self._chunk.groups.iloc[ind]['alt_base'],
                               texify(msg),
@@ -325,7 +325,7 @@ class DiagnosticPlot:
 
             # Display the actual METAR text
             msg = r'\smaller ' + wmo.okta2symb(self._chunk.layers.iloc[ind]['okta'],
-                use_metsymb=(dynamic.AMPYCLOUD_PRMS.MPL_STYLE == 'metsymb')) +\
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
                 ' ' + self._chunk.layers.iloc[ind]['code']
             self._axs[3].text(0.5, self._chunk.layers.iloc[ind]['alt_base'],
                               texify(msg),
@@ -351,10 +351,10 @@ class DiagnosticPlot:
         msg = r'\smaller max. hits per layer: ' + str(self._chunk.max_hits_per_layer)
         msg += r'$^{\uparrow\, '
         msg += str(int(np.ceil(self._chunk.max_hits_per_layer/100*
-                       dynamic.AMPYCLOUD_PRMS.OKTA_LIM8)))
+                       self._chunk.prms['OKTA_LIM8'])))
         msg += r'}_{\downarrow\, '
         msg += str(int(np.floor(self._chunk.max_hits_per_layer/100*
-                       dynamic.AMPYCLOUD_PRMS.OKTA_LIM0)))
+                       self._chunk.prms['OKTA_LIM0'])))
         msg += r'}$'
 
         self._axs[0].text(-0.14, -0.21, texify(msg),
@@ -427,30 +427,30 @@ class DiagnosticPlot:
             # we need to derive them by hand given what was requested by the user.
             (dt_scale_kwargs, dt_descale_kwargs) = \
                 get_scaling_kwargs(self._chunk.data['dt'].values,
-                                  dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_mode,
-                                  dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_kwargs)
+                                   self._chunk.prms['SLICING_PRMS']['dt_scale_mode'],
+                                   self._chunk.prms['SLICING_PRMS']['dt_scale_kwargs'])
 
             (alt_scale_kwargs, alt_descale_kwargs) = \
                 get_scaling_kwargs(self._chunk.data['alt'].values,
-                                  dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.alt_scale_mode,
-                                  dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.alt_scale_kwargs)
+                                   self._chunk.prms['SLICING_PRMS']['alt_scale_mode'],
+                                   self._chunk.prms['SLICING_PRMS']['alt_scale_kwargs'])
 
             # Then add the secondary axis, using partial function to define the back-and-forth
             # conversion functions.
             secax_x = self._axs[0].secondary_xaxis(1.06,
                 functions=(partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_mode,
+                                   fct=self._chunk.prms['SLICING_PRMS']['dt_scale_mode'],
                                    **dt_scale_kwargs),
                            partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_mode,
+                                   fct=self._chunk.prms['SLICING_PRMS']['dt_scale_mode'],
                                    **dt_descale_kwargs)))
 
             secax_y = self._axs[0].secondary_yaxis(1.03,
                 functions=(partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.alt_scale_mode,
+                                   fct=self._chunk.prms['SLICING_PRMS']['alt_scale_mode'],
                                    **alt_scale_kwargs),
                            partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.alt_scale_mode,
+                                   fct=self._chunk.prms['SLICING_PRMS']['alt_scale_mode'],
                                    **alt_descale_kwargs)))
 
             # Add the axis labels
@@ -474,30 +474,30 @@ class DiagnosticPlot:
             # we need to derive them by hand given what was requested by the user.
             (dt_scale_kwargs, dt_descale_kwargs) = \
                 get_scaling_kwargs(self._chunk.data['dt'].values,
-                                  dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.dt_scale_mode,
-                                  dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.dt_scale_kwargs)
+                                   self._chunk.prms['GROUPING_PRMS']['dt_scale_mode'],
+                                   self._chunk.prms['GROUPING_PRMS']['dt_scale_kwargs'])
 
             (alt_scale_kwargs, alt_descale_kwargs) = \
                 get_scaling_kwargs(self._chunk.data['alt'].values,
-                                  dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.alt_scale_mode,
-                                  dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.alt_scale_kwargs)
+                                   self._chunk.prms['GROUPING_PRMS']['alt_scale_mode'],
+                                   self._chunk.prms['GROUPING_PRMS']['alt_scale_kwargs'])
 
             # Then add the secondary axis, using partial function to define the back-and-forth
             # conversion functions.
             secax_x = self._axs[0].secondary_xaxis(1.25,
                 functions=(partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.dt_scale_mode,
+                                   fct=self._chunk.prms['GROUPING_PRMS']['dt_scale_mode'],
                                    **dt_scale_kwargs),
                            partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.dt_scale_mode,
+                                   fct=self._chunk.prms['GROUPING_PRMS']['dt_scale_mode'],
                                    **dt_descale_kwargs)))
 
             secax_y = self._axs[0].secondary_yaxis(1.14,
                 functions=(partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.alt_scale_mode,
+                                   fct=self._chunk.prms['GROUPING_PRMS']['alt_scale_mode'],
                                    **alt_scale_kwargs),
                            partial(scaler.apply_scaling,
-                                   fct=dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS.alt_scale_mode,
+                                   fct=self._chunk.prms['GROUPING_PRMS']['alt_scale_mode'],
                                    **alt_descale_kwargs)))
 
             # Add the axis labels

--- a/src/ampycloud/plots/diagnostics.py
+++ b/src/ampycloud/plots/diagnostics.py
@@ -29,10 +29,11 @@ from ..version import VERSION
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 class DiagnosticPlot:
     """ Class used to create diagnostic plots. """
 
-    def __init__(self, chunk : CeiloChunk) -> None:
+    def __init__(self, chunk: CeiloChunk) -> None:
         """ The init function.
 
         Args:
@@ -87,7 +88,7 @@ class DiagnosticPlot:
         """ Assign the fig attribute. """
         self._fig, self._axs = self.setup_fig()
 
-    def show_hits_only(self, show_ceilos : bool = False) -> None:
+    def show_hits_only(self, show_ceilos: bool = False) -> None:
         """ Shows the ceilometer hits alone.
 
         Args:
@@ -108,7 +109,7 @@ class DiagnosticPlot:
             # Get a list of ceilo colors from the cycler.
             ceilo_clrs = plt.rcParams['axes.prop_cycle'].by_key()['color']
             # Assign them to each hit
-            symb_clrs = [ceilo_clrs[self._chunk.ceilos.index(item)%len(ceilo_clrs)]
+            symb_clrs = [ceilo_clrs[self._chunk.ceilos.index(item) % len(ceilo_clrs)]
                          for item in self._chunk.data['ceilo']]
 
         # What are the VV hits ?
@@ -169,7 +170,6 @@ class DiagnosticPlot:
                           ha='center', va='bottom',
                           transform=self._axs[1].transAxes)
 
-
         # Get a list of approved colors
         all_clrs = plt.rcParams['axes.prop_cycle'].by_key()['color']
 
@@ -220,15 +220,16 @@ class DiagnosticPlot:
                 warn = ''
 
             # Show the slice METAR text
-            msg = r'\smaller ' + wmo.okta2symb(self._chunk.slices.iloc[ind]['okta'],
-                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
-                ' ' + self._chunk.slices.iloc[ind]['code'] + warn
+            msg = r'\smaller ' + wmo.okta2symb(
+                self._chunk.slices.iloc[ind]['okta'],
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')
+            ) + ' ' + self._chunk.slices.iloc[ind]['code'] + warn
             self._axs[1].text(0.5, self._chunk.slices.iloc[ind]['alt_base'],
                               texify(msg),
                               va='center', ha='center', color=base_clr,
                               bbox=dict(facecolor='none', edgecolor=base_clr, alpha=alpha, ls='--'))
 
-    def show_groups(self, show_points : bool = False) -> None:
+    def show_groups(self, show_points: bool = False) -> None:
         """ Show the group data.
 
         Args:
@@ -249,12 +250,12 @@ class DiagnosticPlot:
             if show_points:
                 # Which hits are in the group ?
                 in_group = np.array(self._chunk.data['group_id'] ==
-                                      self._chunk.groups.at[ind, 'original_id'])
+                                    self._chunk.groups.at[ind, 'original_id'])
 
                 # I can finally show the points ...
                 self._axs[0].scatter(self._chunk.data[in_group]['dt'],
                                      self._chunk.data[in_group]['alt'],
-                                     marker=MRKS[ind%len(MRKS)],
+                                     marker=MRKS[ind % len(MRKS)],
                                      s=40, c='none', edgecolor='gray', lw=1, zorder=10, alpha=0.5)
 
             # Stop here if that group has 0 okta.
@@ -264,18 +265,19 @@ class DiagnosticPlot:
             # Prepare to display the METAR codes for the groups.
             # First, check if it is significant or not.
             if self._chunk.groups.iloc[ind]['significant']:
-                alpha=1
+                alpha = 1
             else:
-                alpha=0
+                alpha = 0
 
             # Then also check if these groups contain multiple sub-layers ...
-            symbs = {-1: r'', 1: r'$-$', 2:r'$=$', 3:r'$\equiv$'}
+            symbs = {-1: r'', 1: r'$-$', 2: r'$=$', 3: r'$\equiv$'}
             warn = ' ' + symbs[self._chunk.groups.iloc[ind]['ncomp']]
 
             # Show the group METAR text
-            msg = r'\smaller ' + wmo.okta2symb(self._chunk.groups.iloc[ind]['okta'],
-                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
-                ' ' + self._chunk.groups.iloc[ind]['code'] + warn
+            msg = r'\smaller ' + wmo.okta2symb(
+                self._chunk.groups.iloc[ind]['okta'],
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')
+            ) + ' ' + self._chunk.groups.iloc[ind]['code'] + warn
             self._axs[2].text(0.5, self._chunk.groups.iloc[ind]['alt_base'],
                               texify(msg),
                               va='center', ha='center', color='gray',
@@ -299,7 +301,7 @@ class DiagnosticPlot:
             # I can finally show the points ...
             self._axs[0].scatter(self._chunk.data[in_layer]['dt'],
                                  self._chunk.data[in_layer]['alt'],
-                                 marker=MRKS[ind%len(MRKS)],
+                                 marker=MRKS[ind % len(MRKS)],
                                  s=40, c='none', edgecolor='k', lw=1, zorder=10, alpha=0.5)
 
             # Draw the line of the layer base
@@ -309,7 +311,7 @@ class DiagnosticPlot:
                 lls = '--'
 
             self._axs[0].axhline(self._chunk.layers.iloc[ind]['alt_base'], xmax=1, c='k',
-                        lw=1, zorder=0, ls=lls, clip_on=False)
+                                 lw=1, zorder=0, ls=lls, clip_on=False)
 
             # Stop here for empty layers
             if self._chunk.layers.iloc[ind]['okta'] == 0:
@@ -318,14 +320,15 @@ class DiagnosticPlot:
             # Prepare to display the METAR codes for the layer.
             # First, check if it is significant, or not.
             if self._chunk.layers.iloc[ind]['significant']:
-                alpha=1
+                alpha = 1
             else:
-                alpha=0
+                alpha = 0
 
             # Display the actual METAR text
-            msg = r'\smaller ' + wmo.okta2symb(self._chunk.layers.iloc[ind]['okta'],
-                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')) +\
-                ' ' + self._chunk.layers.iloc[ind]['code']
+            msg = r'\smaller ' + wmo.okta2symb(
+                self._chunk.layers.iloc[ind]['okta'],
+                use_metsymb=(self._chunk.prms['MPL_STYLE'] == 'metsymb')
+            ) + ' ' + self._chunk.layers.iloc[ind]['code']
             self._axs[3].text(0.5, self._chunk.layers.iloc[ind]['alt_base'],
                               texify(msg),
                               va='center', ha='center', color='k',
@@ -349,10 +352,10 @@ class DiagnosticPlot:
 
         msg = r'\smaller max. hits per layer: ' + str(self._chunk.max_hits_per_layer)
         msg += r'$^{\uparrow\, '
-        msg += str(int(np.ceil(self._chunk.max_hits_per_layer/100*
+        msg += str(int(np.ceil(self._chunk.max_hits_per_layer/100 *
                        self._chunk.prms['OKTA_LIM8'])))
         msg += r'}_{\downarrow\, '
-        msg += str(int(np.floor(self._chunk.max_hits_per_layer/100*
+        msg += str(int(np.floor(self._chunk.max_hits_per_layer/100 *
                        self._chunk.prms['OKTA_LIM0'])))
         msg += r'}$'
 
@@ -368,11 +371,11 @@ class DiagnosticPlot:
         if self._chunk.ref_dt is not None:
             msg += [r'\smaller $\Delta t_{\rm ref}$: ' + '{}'.format(self._chunk.ref_dt)]
 
-        if not len(msg)==0:
+        if not len(msg) == 0:
             self._axs[2].text(0.5, -0.02, texify(r'\smaller ' + '\n '.join(msg)),
                               transform=self._axs[2].transAxes, ha='center', va='top')
 
-    def add_ref_metar(self, name : str, metar : str) -> None:
+    def add_ref_metar(self, name: str, metar: str) -> None:
         """ Display a reference METAR, for example from human observers, different code, etc ...
 
         Args:
@@ -386,7 +389,7 @@ class DiagnosticPlot:
             # Show it if it contains something ...
             self._axs[2].text(0.5, 1.3, texify(msg),
                               transform=self._axs[2].transAxes, color='k', ha='center',
-                              #bbox=dict(facecolor='none', edgecolor='k', alpha=1,
+                              # bbox=dict(facecolor='none', edgecolor='k', alpha=1,
                               #          boxstyle='round, pad=0.25')
                               )
 
@@ -436,7 +439,8 @@ class DiagnosticPlot:
 
             # Then add the secondary axis, using partial function to define the back-and-forth
             # conversion functions.
-            secax_x = self._axs[0].secondary_xaxis(1.06,
+            secax_x = self._axs[0].secondary_xaxis(
+                1.06,
                 functions=(partial(scaler.apply_scaling,
                                    fct=self._chunk.prms['SLICING_PRMS']['dt_scale_mode'],
                                    **dt_scale_kwargs),
@@ -444,7 +448,8 @@ class DiagnosticPlot:
                                    fct=self._chunk.prms['SLICING_PRMS']['dt_scale_mode'],
                                    **dt_descale_kwargs)))
 
-            secax_y = self._axs[0].secondary_yaxis(1.03,
+            secax_y = self._axs[0].secondary_yaxis(
+                1.03,
                 functions=(partial(scaler.apply_scaling,
                                    fct=self._chunk.prms['SLICING_PRMS']['alt_scale_mode'],
                                    **alt_scale_kwargs),
@@ -483,7 +488,8 @@ class DiagnosticPlot:
 
             # Then add the secondary axis, using partial function to define the back-and-forth
             # conversion functions.
-            secax_x = self._axs[0].secondary_xaxis(1.25,
+            secax_x = self._axs[0].secondary_xaxis(
+                1.25,
                 functions=(partial(scaler.apply_scaling,
                                    fct=self._chunk.prms['GROUPING_PRMS']['dt_scale_mode'],
                                    **dt_scale_kwargs),
@@ -491,7 +497,8 @@ class DiagnosticPlot:
                                    fct=self._chunk.prms['GROUPING_PRMS']['dt_scale_mode'],
                                    **dt_descale_kwargs)))
 
-            secax_y = self._axs[0].secondary_yaxis(1.14,
+            secax_y = self._axs[0].secondary_yaxis(
+                1.14,
                 functions=(partial(scaler.apply_scaling,
                                    fct=self._chunk.prms['GROUPING_PRMS']['alt_scale_mode'],
                                    **alt_scale_kwargs),
@@ -507,7 +514,7 @@ class DiagnosticPlot:
             secax_x.tick_params(axis='x', which='both', labelsize=rcParams['font.size']-2)
             secax_y.tick_params(axis='y', which='both', labelsize=rcParams['font.size']-2)
 
-    def save(self, fn_out : str, fmts : list = None) -> None:
+    def save(self, fn_out: str, fmts: list = None) -> None:
         """ Saves the plot to file.
 
         Args:

--- a/src/ampycloud/plots/diagnostics.py
+++ b/src/ampycloud/plots/diagnostics.py
@@ -335,7 +335,7 @@ class DiagnosticPlot:
     def add_vv_legend(self) -> None:
         """ Adds a legend about the VV hits."""
         msg = r'\smaller $\circ\equiv\mathrm{VV\ hit}$'
-        self._axs[0].text(0.01, 1.35, texify(msg),
+        self._axs[0].text(-0.01, 1.35, texify(msg),
                           transform=self._axs[0].transAxes, ha='right', va='top', c='k',
                           bbox=dict(facecolor='w', edgecolor='k', alpha=1))
 

--- a/src/ampycloud/plots/diagnostics.py
+++ b/src/ampycloud/plots/diagnostics.py
@@ -367,7 +367,7 @@ class DiagnosticPlot:
         if self._chunk.geoloc is not None:
             msg += [r'{}'.format(self._chunk.geoloc)]
         if self._chunk.ref_dt is not None:
-            msg += [r'\smaller $\Delta t=0$: {}'.format(self._chunk.ref_dt)]
+            msg += [r'\smaller $\Delta t_{\rm ref}$: ' + '{}'.format(self._chunk.ref_dt)]
 
         if not len(msg)==0:
             self._axs[2].text(0.5, -0.02, texify(r'\smaller ' + '\n '.join(msg)),

--- a/src/ampycloud/plots/diagnostics.py
+++ b/src/ampycloud/plots/diagnostics.py
@@ -24,7 +24,6 @@ from .hardcoded import WIDTH_TWOCOL, MRKS
 from .tools import texify, get_scaling_kwargs
 from .. import wmo
 from ..data import CeiloChunk
-from .. import dynamic
 from ..version import VERSION
 
 # Instantiate the module logger

--- a/src/ampycloud/plots/hardcoded.py
+++ b/src/ampycloud/plots/hardcoded.py
@@ -9,10 +9,10 @@ Module contains: hardcoded plotting parameters
 """
 
 #: float: Width of a 1-column plot [inches], to fit in scientific articles when scaled by 50%
-WIDTH_ONECOL : float = 6.92
+WIDTH_ONECOL: float = 6.92
 
 #: float: Width of a 2-column plot [inches], to fit in scientific articles when scaled by 50%
-WIDTH_TWOCOL : float = 14.16
+WIDTH_TWOCOL: float = 14.16
 
 #: list: list of markers, for the different cloud layers
 MRKS = ['s', '^', 'o', 'v', 'D', '>', 'h', '<']

--- a/src/ampycloud/plots/secondary.py
+++ b/src/ampycloud/plots/secondary.py
@@ -25,10 +25,11 @@ from .tools import texify, set_mplstyle
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @set_mplstyle
 @log_func_call(logger)
 def scaling_fcts(show: bool = True,
-                 save_stem : str = None, save_fmts : Union[list, str] = None) -> None:
+                 save_stem: str = None, save_fmts: Union[list, str] = None) -> None:
     """ Plots the different scaling functions.
 
     This is a small utility routine to rapidly see the different altitude scaling options used by
@@ -69,13 +70,14 @@ def scaling_fcts(show: bool = True,
     alts = np.arange(0, 25000, 10)
 
     # Plot the slicing scale
-    ax1.plot(alts, apply_scaling(alts, fct='shift-and-scale', **{'scale':1000}), c='k', lw=2)
+    ax1.plot(alts, apply_scaling(alts, fct='shift-and-scale', **{'scale': 1000}), c='k', lw=2)
     ax1.set_title(texify(r'\smaller shift-and-scale'))
 
     ax2.plot(alts, apply_scaling(alts, fct='minmax-scale'), c='k', lw=2)
     ax2.set_title(texify(r'\smaller minmax-scale'))
 
-    ax3.plot(alts, apply_scaling(alts, fct='step-scale',
+    ax3.plot(alts, apply_scaling(
+        alts, fct='step-scale',
         **dynamic.AMPYCLOUD_PRMS['GROUPING_PRMS']['alt_scale_kwargs']), c='k', lw=2)
     ax3.set_title(texify(r'\smaller step-scale'))
 

--- a/src/ampycloud/plots/secondary.py
+++ b/src/ampycloud/plots/secondary.py
@@ -76,7 +76,7 @@ def scaling_fcts(show: bool = True,
     ax2.set_title(texify(r'\smaller minmax-scale'))
 
     ax3.plot(alts, apply_scaling(alts, fct='step-scale',
-        **dynamic.AMPYCLOUD_PRMS.GROUPING_PRMS['alt_scale_kwargs']), c='k', lw=2)
+        **dynamic.AMPYCLOUD_PRMS['GROUPING_PRMS']['alt_scale_kwargs']), c='k', lw=2)
     ax3.set_title(texify(r'\smaller step-scale'))
 
     for ax in [ax1, ax2, ax3]:

--- a/src/ampycloud/plots/tools.py
+++ b/src/ampycloud/plots/tools.py
@@ -84,19 +84,19 @@ def set_mplstyle(func : Callable) -> Callable:
             prms = yaml.safe_load(fil)
 
         # What is the plotting style chosen by the user
-        spec_style = dynamic.AMPYCLOUD_PRMS.MPL_STYLE
+        spec_style = dynamic.AMPYCLOUD_PRMS['MPL_STYLE']
         # Let's do some sanity checks on the user input.
         # 0) If I was asked to do nothing special, then do nothing special ...
         if spec_style is None or spec_style == 'base':
             pass
         # 2) Else, I need a string or I cry ...
         elif not isinstance(spec_style, str):
-            raise AmpycloudError('Ouch ! dynamic.AMPYCLOUD_PRMS.MPL_STYLE type unknown:'+
+            raise AmpycloudError('Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] type unknown:'+
                                  f' {type(spec_style)}')
         # 3) Is that a supported style ?
         elif spec_style not in valid_styles():
-            raise AmpycloudError(f'Ouch ! dynamic.AMPYCLOUD_PRMS.MPL_STYLE {spec_style} unknown.'+
-                                 f' Should be one of {valid_styles()}.')
+            raise AmpycloudError(f'Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] {spec_style}'+
+                                 f' unknown. Should be one of {valid_styles()}.')
         # 4) Request seems legit ... let's load the spec_style ...
         else:
             with open(pth / f'{spec_style}.mplstyle') as fil:
@@ -167,12 +167,8 @@ def get_scaling_kwargs(data : np.ndarray, mode: str, kwargs : dict) -> tuple:
         tuple: (scale_kwargs, descale_kwargs), the two dict with parameters for the forward/backward
         scaling.
 
-    Todo:
-        Cleanup the code once #25 is fixed.
-
     """
 
-    # TODO: Once issue #25 is fixed, maybe update these lines ...
     # Let's create a storage dict, and fill it with what I got from the user.
     scale_kwargs = {}
     scale_kwargs.update(kwargs)

--- a/src/ampycloud/plots/tools.py
+++ b/src/ampycloud/plots/tools.py
@@ -27,17 +27,20 @@ from .. import dynamic, scaler
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 def style_pth() -> Path:
     """ Returns the Path to the ampycloud plotting styles. """
 
     return Path(__file__).parent / 'mpl_styles'
+
 
 def valid_styles() -> list:
     """ Returns the list of valid plotting styles. """
 
     return [item.stem for item in style_pth().glob('*.mplstyle')]
 
-def set_mplstyle(func : Callable) -> Callable:
+
+def set_mplstyle(func: Callable) -> Callable:
     """ Intended to be used as a decorator around plotting functions, to set the plotting style.
 
     By defaults, the ``base`` ampycloud style will be enabled. Motivated users can tweak it further
@@ -91,11 +94,11 @@ def set_mplstyle(func : Callable) -> Callable:
             pass
         # 2) Else, I need a string or I cry ...
         elif not isinstance(spec_style, str):
-            raise AmpycloudError('Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] type unknown:'+
+            raise AmpycloudError('Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] type unknown:' +
                                  f' {type(spec_style)}')
         # 3) Is that a supported style ?
         elif spec_style not in valid_styles():
-            raise AmpycloudError(f'Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] {spec_style}'+
+            raise AmpycloudError(f'Ouch ! dynamic.AMPYCLOUD_PRMS["MPL_STYLE"] {spec_style}' +
                                  f' unknown. Should be one of {valid_styles()}.')
         # 4) Request seems legit ... let's load the spec_style ...
         else:
@@ -106,7 +109,7 @@ def set_mplstyle(func : Callable) -> Callable:
         # Issue #18: I need to set `text.latex.preamble` out of context if I want it to be
         # taken into account.
         if 'text.latex.preamble' in prms.keys():
-            plt.style.use({'text.latex.preamble':prms['text.latex.preamble']})
+            plt.style.use({'text.latex.preamble': prms['text.latex.preamble']})
 
         # Finally, apply the base plotting style
         with plt.style.context(prms):
@@ -118,7 +121,7 @@ def set_mplstyle(func : Callable) -> Callable:
 
 
 @log_func_call(logger)
-def texify(msg : str) -> str:
+def texify(msg: str) -> str:
     """ Small utility function that TeX-ifies a string to make it LaTeX robust if warranted by the
     current rcParams settings.
 
@@ -137,7 +140,7 @@ def texify(msg : str) -> str:
         msg = msg.replace('%', r'\%')
 
         # Here, I want to clean the underscore, but ONLY outside of math mode.
-        msg = [item.replace('_', r'\_') if ind%2==0 else item
+        msg = [item.replace('_', r'\_') if ind % 2 == 0 else item
                for (ind, item) in enumerate(msg.split('$'))]
         msg = '$'.join(msg)
     # Next cleanup any LaTeX-specific stuff ...
@@ -148,8 +151,9 @@ def texify(msg : str) -> str:
 
     return msg
 
+
 @log_func_call(logger)
-def get_scaling_kwargs(data : np.ndarray, mode: str, kwargs : dict) -> tuple:
+def get_scaling_kwargs(data: np.ndarray, mode: str, kwargs: dict) -> tuple:
     """ Utility function to extract the **actual, deterministic** parameters required to scale the
     data, given a set of user-defined parameters.
 

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 MeteoSwiss, contributors listed in AUTHORS.
+# Copyright (c) 2021-2022 MeteoSwiss, contributors listed in AUTHORS.
 #
 # Distributed under the terms of the 3-Clause BSD License.
 #

--- a/src/ampycloud/scaler.py
+++ b/src/ampycloud/scaler.py
@@ -20,9 +20,10 @@ from .logger import log_func_call
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def shift_and_scale(vals : np.ndarray, shift : Union[int, float] = None,
-                    scale : Union[int, float] = 1, mode : str = 'do') -> np.ndarray:
+def shift_and_scale(vals: np.ndarray, shift: Union[int, float] = None,
+                    scale: Union[int, float] = 1, mode: str = 'do') -> np.ndarray:
     """ Shift (by a constant) and scale (by a constant) the data.
 
     Args:
@@ -54,11 +55,12 @@ def shift_and_scale(vals : np.ndarray, shift : Union[int, float] = None,
 
     raise AmpycloudError(f' Ouch ! mode unknown: {mode}')
 
+
 @log_func_call(logger)
-def minmax_scale(vals : np.ndarray,
-                 min_val : Union[float, int] = None,
-                 max_val : Union[float, int] = None,
-                 mode : str = 'do') -> np.ndarray:
+def minmax_scale(vals: np.ndarray,
+                 min_val: Union[float, int] = None,
+                 max_val: Union[float, int] = None,
+                 mode: str = 'do') -> np.ndarray:
     """ Rescale the data onto a [0, 1] interval, possibly forcing a specific and/or minimum
         interval range.
 
@@ -89,8 +91,9 @@ def minmax_scale(vals : np.ndarray,
 
     raise AmpycloudError(f' Ouch ! mode unknown: {mode}')
 
+
 @log_func_call(logger)
-def minrange2minmax(vals : np.ndarray, min_range : Union[int, float] = 0) -> tuple:
+def minrange2minmax(vals: np.ndarray, min_range: Union[int, float] = 0) -> tuple:
     """ Transform a minimum range into a pair of min/max values.
 
     Args:
@@ -119,8 +122,8 @@ def minrange2minmax(vals : np.ndarray, min_range : Union[int, float] = 0) -> tup
 
 
 @log_func_call(logger)
-def step_scale(vals : np.ndarray,
-                 steps : list, scales : list, mode : str = 'do') -> np.ndarray:
+def step_scale(vals: np.ndarray,
+               steps: list, scales: list, mode: str = 'do') -> np.ndarray:
     """ Scales values step-wise, with different constants bewteen specific steps.
 
     Values are divided by scales[i] between steps[i-1:i].
@@ -186,8 +189,9 @@ def step_scale(vals : np.ndarray,
 
     return out
 
+
 @log_func_call(logger)
-def convert_kwargs(vals : np.ndarray, fct : str, **kwargs : dict) -> dict:
+def convert_kwargs(vals: np.ndarray, fct: str, **kwargs: dict) -> dict:
     """ Converts the user-input keywords such that they can be fed to the underlying scaling
     functions.
 
@@ -206,8 +210,8 @@ def convert_kwargs(vals : np.ndarray, fct : str, **kwargs : dict) -> dict:
         matter the underlying dataset (as is required for plotting a secondary axis).
 
         Essentially, this function allows to feed either "user" or "deterministic" keywords to
-        :py:func:`.apply_scaling`, such that the former will be turned into the latter, and the latter will
-        remain untouched.
+        :py:func:`.apply_scaling`, such that the former will be turned into the latter, and the
+        latter will remain untouched.
 
     """
 
@@ -245,7 +249,7 @@ def convert_kwargs(vals : np.ndarray, fct : str, **kwargs : dict) -> dict:
                 (kwargs['min_val'], kwargs['max_val']) = minrange2minmax(vals, min_range)
                 return kwargs
 
-            if kwargs['mode']=='undo':
+            if kwargs['mode'] == 'undo':
                 raise AmpycloudError('Ouch ! I cannot get `min_val` and `max_val` from' +
                                      ' minmax-scaled data !')
 
@@ -266,8 +270,9 @@ def convert_kwargs(vals : np.ndarray, fct : str, **kwargs : dict) -> dict:
 
     raise AmpycloudError(f'Ouch ! scaling fct unknown: {fct}')
 
+
 @log_func_call(logger)
-def apply_scaling(vals : np.ndarray, fct : str = None, **kwargs : dict) -> np.ndarray:
+def apply_scaling(vals: np.ndarray, fct: str = None, **kwargs: dict) -> np.ndarray:
     """ Umbrella scaling routine, that gathers all the individual ones under a single entry point.
 
     Args:

--- a/src/ampycloud/utils/mocker.py
+++ b/src/ampycloud/utils/mocker.py
@@ -23,8 +23,9 @@ from .. import hardcoded
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def flat_layer(dts : np.array, alt : float, alt_std : float, sky_cov_frac : float) -> pd.DataFrame:
+def flat_layer(dts: np.array, alt: float, alt_std: float, sky_cov_frac: float) -> pd.DataFrame:
     """ Generates a mock, flat, Gaussian cloud layer around a given altitude.
 
     Args:
@@ -47,7 +48,7 @@ def flat_layer(dts : np.array, alt : float, alt_std : float, sky_cov_frac : floa
     # Generate the random altitude data
     out['alt'] = np.random.normal(loc=alt, scale=alt_std, size=n_pts)
     # Cleanup any negative altitudes, if warranted.
-    out.loc[out['alt']<=0, 'alt'] = np.nan
+    out.loc[out['alt'] <= 0, 'alt'] = np.nan
     out['dt'] = dts
 
     # Empty hits to get the requested sky coverage fraction
@@ -60,9 +61,10 @@ def flat_layer(dts : np.array, alt : float, alt_std : float, sky_cov_frac : floa
 
     return out
 
+
 @log_func_call(logger)
-def sin_layer(dts : np.array, alt : float, alt_std : float, sky_cov_frac : float,
-              period : Union[int, float], amplitude : Union[int, float]) -> pd.DataFrame:
+def sin_layer(dts: np.array, alt: float, alt_std: float, sky_cov_frac: float,
+              period: Union[int, float], amplitude: Union[int, float]) -> pd.DataFrame:
     """ Generates a sinusoidal cloud layer.
 
     Args:
@@ -87,8 +89,8 @@ def sin_layer(dts : np.array, alt : float, alt_std : float, sky_cov_frac : float
     return out
 
 
-def mock_layers(n_ceilos : int, lookback_time : float, hit_gap: float,
-                layer_prms : list) -> pd.DataFrame:
+def mock_layers(n_ceilos: int, lookback_time: float, hit_gap: float,
+                layer_prms: list) -> pd.DataFrame:
     """ Generate a mock set of cloud layers for a specified number of ceilometers.
 
     Args:
@@ -121,11 +123,11 @@ def mock_layers(n_ceilos : int, lookback_time : float, hit_gap: float,
     for (ind, item) in enumerate(layer_prms):
         if not isinstance(item, dict):
             raise AmpycloudError(f'Ouch ! Element {ind} from layer_prms should be a dict,' +
-                                  f' not: {type(item)}')
+                                 f' not: {type(item)}')
         if not all(key in item.keys() for key in ['alt', 'alt_std', 'sky_cov_frac',
                                                   'period', 'amplitude']):
-            raise AmpycloudError('Ouch ! One or more of the following dict keys are missing in '+
-                                 f"layer_prms[{ind}]: 'alt', 'alt_std', 'sky_cov_frac',"+
+            raise AmpycloudError('Ouch ! One or more of the following dict keys are missing in ' +
+                                 f"layer_prms[{ind}]: 'alt', 'alt_std', 'sky_cov_frac'," +
                                  "'period', 'amplitude'.")
 
     # Let's create the layers individually for each ceilometer
@@ -148,13 +150,13 @@ def mock_layers(n_ceilos : int, lookback_time : float, hit_gap: float,
         # This needs to be done on a point by point basis, given that layers can cross each other.
         for dt in np.unique(layers['dt']):
             # Get the hit altitudes, and sort them from lowest to highest
-            alts = layers[layers['dt']==dt]['alt'].sort_values(axis=0)
+            alts = layers[layers['dt'] == dt]['alt'].sort_values(axis=0)
 
             # Then deal with the other ones
             for (a, alt) in enumerate(alts):
 
                 # Except for the first one, any NaN hit gets dropped
-                if a>0 and np.isnan(alt):
+                if a > 0 and np.isnan(alt):
                     layers.drop(index=alts.index[a],
                                 inplace=True)
                 elif np.isnan(alt):
@@ -180,6 +182,7 @@ def mock_layers(n_ceilos : int, lookback_time : float, hit_gap: float,
 
     return out
 
+
 def canonical_demo_data() -> pd.DataFrame:
     """ This function creates the canonical ampycloud demonstration dataset, that can be used to
     illustrate the full behavior of the algorithm.
@@ -198,7 +201,6 @@ def canonical_demo_data() -> pd.DataFrame:
             {'alt': 2000, 'alt_std': 100, 'sky_cov_frac': 0.5, 'period': 10, 'amplitude': 0},
             {'alt': 5000, 'alt_std': 200, 'sky_cov_frac': 1, 'period': 2400, 'amplitude': 1000},
             ]
-
 
     # Reset the random seed, but only do this temporarily, so as to not mess things up for the user.
     with utils.tmp_seed(42):

--- a/src/ampycloud/utils/performance.py
+++ b/src/ampycloud/utils/performance.py
@@ -20,8 +20,9 @@ from ..core import demo
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def get_speed_benchmark(niter : int = 10) -> tuple:
+def get_speed_benchmark(niter: int = 10) -> tuple:
     """ This function will run and time :py:func:`ampycloud.core.demo` to assess the code's
     performance on a given machine.
 

--- a/src/ampycloud/utils/performance.py
+++ b/src/ampycloud/utils/performance.py
@@ -31,7 +31,7 @@ def get_speed_benchmark(niter : int = 10) -> tuple:
     the mock dataset from its processing.
 
     Returns:
-        int, float, float, float, float, float: niter, mean, std, median, min, max:
+        int, float, float, float, float, float: niter, mean, std, median, min, max, all in s.
 
     """
 

--- a/src/ampycloud/utils/utils.py
+++ b/src/ampycloud/utils/utils.py
@@ -24,9 +24,10 @@ from .. import hardcoded
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def check_data_consistency(pdf : pd.DataFrame,
-                           req_cols : dict = None) -> pd.DataFrame:
+def check_data_consistency(pdf: pd.DataFrame,
+                           req_cols: dict = None) -> pd.DataFrame:
     """ Assesses whether a given :py:class:`pandas.DataFrame` is compatible with the requirements
     of ampycloud.
 
@@ -51,7 +52,8 @@ def check_data_consistency(pdf : pd.DataFrame,
         'ceilo'/pd.StringDtype(), 'dt'/float, 'alt'/float, 'type'/int
 
     The ``ceilo`` column contains the names/ids of the ceilometers as ``pd.StringDtype()``.
-    See `the pandas documentation <https://pandas.pydata.org/docs/reference/api/pandas.StringDtype.html>`__
+    See the pandas
+    `documentation <https://pandas.pydata.org/docs/reference/api/pandas.StringDtype.html>`__
     for more info about this type.
 
     The ``dt`` column contains time deltas, in seconds, between a given ceilometer
@@ -116,7 +118,7 @@ def check_data_consistency(pdf : pd.DataFrame,
 
     # First things first, make sure I was fed a pandas DataFrame
     if not isinstance(data, pd.DataFrame):
-        raise AmpycloudError('Ouch ! I was expecting data as a pandas DataFrame,'+
+        raise AmpycloudError('Ouch ! I was expecting data as a pandas DataFrame,' +
                              f' not: {type(data)}')
 
     # Make sure the dataframe is not empty.
@@ -156,11 +158,11 @@ def check_data_consistency(pdf : pd.DataFrame,
         msgs += ['Huh ! Some type=0 hits have non-NaNs altitude values ?!']
     if np.any(np.isnan(data.loc[data.type == 1, 'alt'])):
         msgs += ['Huh ! Some type=1 hits have NaNs altitude values ?!']
-    if not np.all(np.in1d(data.loc[data.type==2, 'dt'].values,
-                          data.loc[data.type==1, 'dt'].values)):
+    if not np.all(np.in1d(data.loc[data.type == 2, 'dt'].values,
+                          data.loc[data.type == 1, 'dt'].values)):
         msgs += ['Huh ! Some type=2 hits have no coincident type=1 hits ?!']
-    if not np.all(np.in1d(data.loc[data.type==3, 'dt'].values,
-                          data.loc[data.type==2, 'dt'].values)):
+    if not np.all(np.in1d(data.loc[data.type == 3, 'dt'].values,
+                          data.loc[data.type == 2, 'dt'].values)):
         msgs += ['Huh ! Some type=3 hits have no coincident type=2 hits ?!']
 
     # Now save all those messages to the log, and raise Warnings as well.
@@ -173,7 +175,7 @@ def check_data_consistency(pdf : pd.DataFrame,
 
 
 @contextlib.contextmanager
-def tmp_seed(seed : int):
+def tmp_seed(seed: int):
     """ Temporarily reset the :py:func:`numpy.random.seed` value.
 
     Adapted from the reply of Paul Panzer on `SO <https://stackoverflow.com/questions/49555991/>`__.
@@ -203,7 +205,7 @@ def tmp_seed(seed : int):
 
 
 @log_func_call(logger)
-def adjust_nested_dict(ref_dict : dict, new_dict : dict, lvls : list = None) -> dict:
+def adjust_nested_dict(ref_dict: dict, new_dict: dict, lvls: list = None) -> dict:
     """ Update a given (nested) dictionnary given a second (possibly incomplete) one.
 
     Args:

--- a/src/ampycloud/utils/utils.py
+++ b/src/ampycloud/utils/utils.py
@@ -200,3 +200,38 @@ def tmp_seed(seed : int):
         yield
     finally:
         np.random.set_state(state)
+
+
+@log_func_call(logger)
+def adjust_nested_dict(ref_dict : dict, new_dict : dict, lvls : list = None) -> dict:
+    """ Update a given (nested) dictionnary given a second (possibly incomplete) one.
+
+    Args:
+        ref_dict (dict): reference dict of dict (of dict of dict ...).
+        new_dict (dict): values to update as a dict (of dict or dict of dict ...)
+        lvls (list, optional): levels of the previous nested dict layers, used for reporting useful
+            errors.
+
+    Returns:
+        dict: the updated dict (of dict of dict of dict ...)
+
+    Note:
+        Inspired from the reply of Alex Martelli and Alex Telon on
+        `SO <https://stackoverflow.com/questions/3232943/>`_.
+
+    """
+
+    if lvls is None:
+        lvls = []
+
+    for key, item in new_dict.items():
+        lvls += [key]
+        if key not in ref_dict.keys():
+            warnings.warn(f'Key unknown (and thus ignored): {".".join(lvls)}', AmpycloudWarning)
+            continue
+        if isinstance(item, dict):
+            ref_dict[key] = adjust_nested_dict(ref_dict[key], item, lvls=lvls)
+        else:
+            ref_dict[key] = item
+
+    return ref_dict

--- a/src/ampycloud/utils/utils.py
+++ b/src/ampycloud/utils/utils.py
@@ -211,8 +211,9 @@ def adjust_nested_dict(ref_dict: dict, new_dict: dict, lvls: list = None) -> dic
     Args:
         ref_dict (dict): reference dict of dict (of dict of dict ...).
         new_dict (dict): values to update as a dict (of dict or dict of dict ...)
-        lvls (list, optional): levels of the previous nested dict layers, used for reporting useful
-            errors.
+        lvls (list of str, optional): names of the keys of the parent nested dict layers, used
+            for reporting useful errors. This is used by the function itself when it calls itself.
+            There is no need for the user to set this to anything at first. Defaults to None.
 
     Returns:
         dict: the updated dict (of dict of dict of dict ...)

--- a/src/ampycloud/version.py
+++ b/src/ampycloud/version.py
@@ -9,4 +9,4 @@ Module contains: ampycloud version
 """
 
 #:str: the one-and-only place where the ampycloud version is set.
-VERSION = '0.3.0.dev0'
+VERSION = '0.4.0.dev0'

--- a/src/ampycloud/wmo.py
+++ b/src/ampycloud/wmo.py
@@ -20,10 +20,11 @@ from .logger import log_func_call
 # Instantiate the module logger
 logger = logging.getLogger(__name__)
 
+
 @log_func_call(logger)
-def perc2okta(val : Union[int, float, np.ndarray],
-              lim0 : Union[int, float] = 0,
-              lim8 : Union[int, float] = 100) -> np.ndarray:
+def perc2okta(val: Union[int, float, np.ndarray],
+              lim0: Union[int, float] = 0,
+              lim8: Union[int, float] = 100) -> np.ndarray:
     """ Converts a sky coverage percentage into oktas.
 
     One okta corresponds to 1/8 of the sky covered by clouds. The cases of 0 and 8 oktas are
@@ -52,7 +53,7 @@ def perc2okta(val : Union[int, float, np.ndarray],
     """
 
     # A basic sanity check
-    if not np.all((val >= 0) * (val <= 100)) :
+    if not np.all((val >= 0) * (val <= 100)):
         raise AmpycloudError(f'Ouch! I need 0<=val<=100, but I got: {val}')
 
     # If I did not receive a numpy array, build one to be efficient afterwards ...
@@ -63,22 +64,23 @@ def perc2okta(val : Union[int, float, np.ndarray],
     out = np.full_like(val, -1., dtype=float)
 
     # Deal with the edge cases first
-    out[(val>=0) * ( val<=lim0)] = 0
-    out[(lim8<=val) * (val<=100)] = 8
+    out[(val >= 0) * (val <= lim0)] = 0
+    out[(lim8 <= val) * (val <= 100)] = 8
 
     # Now deal with the other cases
-    out[out==-1] = val[out==-1]/(100/8)
+    out[out == -1] = val[out == -1]/(100/8)
     # Now we round/floor/ceil as required, remembering that the 1 and 7 okta bins are special.
-    out[out<1] = np.ceil(out[out<1])
-    out[out>7] = np.floor(out[out>7])
+    out[out < 1] = np.ceil(out[out < 1])
+    out[out > 7] = np.floor(out[out > 7])
     # Everything else, we just round as usual
     out = np.round(out)
 
     # Return ints, to make it clear that we do not work with fractional oktas
     return out.astype(int)
 
+
 @log_func_call(logger)
-def okta2code(val : int) -> str:
+def okta2code(val: int) -> str:
     """ Convert an okta value to a METAR code.
 
     Conversion is as follows:
@@ -118,7 +120,7 @@ def okta2code(val : int) -> str:
 
 
 @log_func_call(logger)
-def okta2symb(val : int, use_metsymb : bool = False) -> str:
+def okta2symb(val: int, use_metsymb: bool = False) -> str:
     """ Convert an okta value to a LaTeX string, possibly using the metsymb LaTeX package.
 
     Args:
@@ -161,8 +163,9 @@ def okta2symb(val : int, use_metsymb : bool = False) -> str:
 
     raise AmpycloudError(f'Ouch ! okta value not understood: {val}')
 
+
 @log_func_call(logger)
-def alt2code(val : Union[int, float]) -> str:
+def alt2code(val: Union[int, float]) -> str:
     """ Function that converts a given altitude in hundreds of ft (3 digit number),
     e.g. 5000 ft -> 050, 500 ft -> 005.
 

--- a/test/ampycloud/plots/test_core.py
+++ b/test/ampycloud/plots/test_core.py
@@ -29,7 +29,7 @@ def test_large_dts(mpls):
     """
 
     if mpls:
-        dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+        dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
     # Let's create some data with only NaNs
     data = pd.DataFrame([['1', 7e5, 1000, 1], ['1', 7e5+1, 1001, 1], ['1', 7e5+2, 1002, 1]],
@@ -42,7 +42,7 @@ def test_large_dts(mpls):
     # Run ampycloud
     chunk = run(data)
 
-    # Uncomment the line below once pytst 7.0 can be pip-installed
+    # Uncomment the line below once pytest 7.0 can be pip-installed
     #with pytest.does_not_warn():
     if True:
         diagnostic(chunk, upto='layers', show_ceilos=False, show=False,
@@ -50,6 +50,40 @@ def test_large_dts(mpls):
                    ref_metar_origin='Large dts', ref_metar='OVC010')
 
     assert Path('pytest_large_dts.pdf').exists
+
+def test_direct_prms(mpls):
+    """ Test that all goes well if users feed params directly to run().
+
+    Args:
+        mpls: False, or the value of MPL_STYLE requested by the user. This is set automatically
+            by a fixture that fetches the corresponding command line argument.
+            See conftest.py for details.
+
+    """
+
+    if mpls:
+        dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
+
+    # Let's create some data with only NaNs
+    data = pd.DataFrame([['1', 0, 1000, 1], ['1', 60, 1001, 1], ['1', 120, 1002, 1]],
+                        columns=['ceilo', 'dt', 'alt', 'type'])
+    data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
+    data['dt'] = data['dt'].astype(float)
+    data['alt'] = data['alt'].astype(float)
+    data['type'] = data['type'].astype(int)
+
+    # Run ampycloud
+    chunk = run(data, prms={'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 120}}} )
+
+    # Uncomment the line below once pytest 7.0 can be pip-installed
+    #with pytest.does_not_warn():
+    if True:
+        diagnostic(chunk, upto='layers', show_ceilos=False, show=False,
+                   save_stem='pytest_direct_prms', save_fmts='png',
+                   ref_metar_origin='Direct prms', ref_metar='OVC010')
+
+    assert Path('pytest_direct_prms.pdf').exists
+
 
 
 def test_diagnostic(mpls):
@@ -64,10 +98,10 @@ def test_diagnostic(mpls):
     reset_prms()
 
     if mpls:
-        dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+        dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
     # Set some MSA to see it on the plot
-    dynamic.AMPYCLOUD_PRMS.MSA = 12345
+    dynamic.AMPYCLOUD_PRMS['MSA'] = 12345
 
     # Get some demo chunk data
     _, chunk = demo()
@@ -98,7 +132,7 @@ def test_empty_plot(mpls):
     """
 
     if mpls:
-        dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+        dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
     # Let's create some data with only NaNs
     data = pd.DataFrame([['1', -100, np.nan, 0], ['1', -99, np.nan, 0]],

--- a/test/ampycloud/plots/test_core.py
+++ b/test/ampycloud/plots/test_core.py
@@ -52,6 +52,7 @@ def test_large_dts(mpls):
 
     assert Path('pytest_large_dts.pdf').exists
 
+
 def test_direct_prms(mpls):
     """ Test that all goes well if users feed params directly to run().
 
@@ -74,7 +75,7 @@ def test_direct_prms(mpls):
     data['type'] = data['type'].astype(int)
 
     # Run ampycloud
-    chunk = run(data, prms={'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 120}}} )
+    chunk = run(data, prms={'GROUPING_PRMS': {'dt_scale_kwargs': {'scale': 120}}})
 
     # The following should not trigger any warning... let's make sure of that.
     with warnings.catch_warnings():
@@ -84,7 +85,6 @@ def test_direct_prms(mpls):
                    ref_metar_origin='Direct prms', ref_metar='OVC010')
 
     assert Path('pytest_direct_prms.pdf').exists
-
 
 
 def test_diagnostic(mpls):

--- a/test/ampycloud/plots/test_core.py
+++ b/test/ampycloud/plots/test_core.py
@@ -10,6 +10,7 @@ Module content: tests for the plots.core module
 
 # Import from Python
 from pathlib import Path
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -42,9 +43,9 @@ def test_large_dts(mpls):
     # Run ampycloud
     chunk = run(data)
 
-    # Uncomment the line below once pytest 7.0 can be pip-installed
-    #with pytest.does_not_warn():
-    if True:
+    # The following should not trigger any warning... let's make sure of that.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         diagnostic(chunk, upto='layers', show_ceilos=False, show=False,
                    save_stem='pytest_large_dts', save_fmts='png',
                    ref_metar_origin='Large dts', ref_metar='OVC010')
@@ -75,9 +76,9 @@ def test_direct_prms(mpls):
     # Run ampycloud
     chunk = run(data, prms={'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 120}}} )
 
-    # Uncomment the line below once pytest 7.0 can be pip-installed
-    #with pytest.does_not_warn():
-    if True:
+    # The following should not trigger any warning... let's make sure of that.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         diagnostic(chunk, upto='layers', show_ceilos=False, show=False,
                    save_stem='pytest_direct_prms', save_fmts='png',
                    ref_metar_origin='Direct prms', ref_metar='OVC010')
@@ -145,9 +146,9 @@ def test_empty_plot(mpls):
     # Run ampycloud
     chunk = run(data)
 
-    # Uncomment the line below once pytst 7.0 can be pip-installed
-    #with pytest.does_not_warn():
-    if True:
+    # The following should not trigger any warning... let's make sure of that.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         diagnostic(chunk, upto='layers', show_ceilos=False, show=False,
                    save_stem='pytest_empty_plot', save_fmts='png',
                    ref_metar_origin='Empty data', ref_metar='NCD')

--- a/test/ampycloud/plots/test_secondary.py
+++ b/test/ampycloud/plots/test_secondary.py
@@ -26,7 +26,7 @@ def test_scaling_fcts(mpls):
     """
 
     if mpls:
-        dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+        dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
     scaling_fcts(show=False, save_stem='pytest_scaling_fcts', save_fmts=['png'])
     assert Path('pytest_large_dts.png').exists

--- a/test/ampycloud/test_cluster.py
+++ b/test/ampycloud/test_cluster.py
@@ -14,6 +14,7 @@ import numpy as np
 # Import from the module to test
 from ampycloud.cluster import clusterize
 
+
 def test_clusterize():
     """ Test clusterize(). """
 

--- a/test/ampycloud/test_core.py
+++ b/test/ampycloud/test_core.py
@@ -9,7 +9,7 @@ Module content: tests for the core module
 """
 
 
-#Import from Python
+# Import from Python
 import os
 from pathlib import Path
 from datetime import datetime
@@ -23,6 +23,7 @@ from ampycloud.errors import AmpycloudWarning
 from ampycloud.utils import mocker
 from ampycloud.data import CeiloChunk
 from ampycloud.core import copy_prm_file, reset_prms, run, metar, demo
+
 
 def test_copy_prm_file():
     """ Test the copy_prm_file routine."""
@@ -39,6 +40,7 @@ def test_copy_prm_file():
     _ = [os.remove(item) for item in save_loc.glob('*')]
     save_loc.rmdir()
 
+
 def test_reset_prms():
     """ Test the reset_prms routine. """
 
@@ -53,6 +55,7 @@ def test_reset_prms():
 
     assert dynamic.AMPYCLOUD_PRMS['OKTA_LIM0'] == ref_val
 
+
 def test_run():
     """ Test the run routine. """
 
@@ -64,9 +67,9 @@ def test_run():
     # Create some fake data to get started
     # 1 very flat layer with no gaps
     mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
-                                   [{'alt':1000, 'alt_std': 10, 'sky_cov_frac': 0.5,
+                                   [{'alt': 1000, 'alt_std': 10, 'sky_cov_frac': 0.5,
                                      'period': 100, 'amplitude': 0},
-                                    {'alt':2000, 'alt_std': 10, 'sky_cov_frac': 0.5,
+                                    {'alt': 2000, 'alt_std': 10, 'sky_cov_frac': 0.5,
                                        'period': 100, 'amplitude': 0}])
 
     out = run(mock_data)
@@ -78,14 +81,15 @@ def test_run():
     assert metar(mock_data) == 'SCT009 SCT019'
 
     # Test the ability to specific parameters locally only
-    out = run(mock_data, prms={'MSA':0})
+    out = run(mock_data, prms={'MSA': 0})
     assert out.metar_msg() == 'NCD'
     assert dynamic.AMPYCLOUD_PRMS['MSA'] is None
 
     # Test that warnings are being raised if a bad parameter is being given
     with warns(AmpycloudWarning):
-        out = run(mock_data, prms={'SMA':0})
+        out = run(mock_data, prms={'SMA': 0})
         assert out.metar_msg() == 'SCT009 SCT019'
+
 
 def test_run_single_point():
     """ Test the code when a single data point is fed to it. """
@@ -113,6 +117,7 @@ def test_run_single_point():
     # Reset the parameters
     reset_prms()
 
+
 def test_demo():
     """ Test the demo routine. """
 
@@ -120,6 +125,7 @@ def test_demo():
 
     assert isinstance(chunk, CeiloChunk)
     assert isinstance(mock_data, pd.DataFrame)
+
 
 def test_datetime():
     """ Test the ability to feed datetime instances. """

--- a/test/ampycloud/test_core.py
+++ b/test/ampycloud/test_core.py
@@ -11,9 +11,9 @@ Module content: tests for the core module
 
 #Import from Python
 import os
-from pytest import warns
 from pathlib import Path
 from datetime import datetime
+from pytest import warns
 import numpy as np
 import pandas as pd
 

--- a/test/ampycloud/test_data.py
+++ b/test/ampycloud/test_data.py
@@ -19,6 +19,7 @@ from ampycloud.data import CeiloChunk
 from ampycloud.utils import mocker
 from ampycloud import dynamic, reset_prms, hardcoded
 
+
 def test_ceilochunk_init():
     """ Test the init method of the CeiloChunk class. """
 
@@ -29,7 +30,7 @@ def test_ceilochunk_init():
     # Create some fake data to get started
     # 1 very flat layer with no gaps
     mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
-                                   [{'alt':1000, 'alt_std': 10, 'sky_cov_frac': 1,
+                                   [{'alt': 1000, 'alt_std': 10, 'sky_cov_frac': 1,
                                      'period': 100, 'amplitude': 0}])
     # The following line is required as long as the mocker module issues mock data with type 99.
     mock_data.iloc[-1, mock_data.columns.get_loc('type')] = 1
@@ -44,8 +45,8 @@ def test_ceilochunk_init():
     dynamic.AMPYCLOUD_PRMS['MSA_HIT_BUFFER'] = 0
     chunk = CeiloChunk(mock_data)
     # Applying the MSA should crop any Type 2 or more hits, and change Type 1 or less to Type 0.
-    assert len(chunk.data) == len(mock_data[mock_data.type <=1])
-    assert not np.any(chunk.data.type>0)
+    assert len(chunk.data) == len(mock_data[mock_data.type <= 1])
+    assert not np.any(chunk.data.type > 0)
     # Verify the class MSA value is correct too ...
     assert chunk.msa == 0
 
@@ -60,22 +61,23 @@ def test_ceilochunk_init():
         _ = CeiloChunk(mock_data[:0])
 
     # Check the ability to manually specifiy parameters at init without messing up the default ones
-    chunk = CeiloChunk(mock_data, prms={'MSA':-30})
+    chunk = CeiloChunk(mock_data, prms={'MSA': -30})
     assert chunk.msa == -30
     assert dynamic.AMPYCLOUD_PRMS['MSA'] == 0
 
     # Check the ability to set nested parameters in one go
-    chunk = CeiloChunk(mock_data, prms={'SLICING_PRMS':{'algo':'test'}})
+    chunk = CeiloChunk(mock_data, prms={'SLICING_PRMS': {'algo': 'test'}})
     assert chunk.prms['SLICING_PRMS']['algo'] == 'test'
     assert dynamic.AMPYCLOUD_PRMS['SLICING_PRMS']['algo'] == 'agglomerative'
 
     # Check that warnings are raised in case bad parameters are given
     with warns(AmpycloudWarning):
-        chunk = CeiloChunk(mock_data, prms={'SMTH_BAD':0})
+        chunk = CeiloChunk(mock_data, prms={'SMTH_BAD': 0})
         assert chunk.prms == dynamic.AMPYCLOUD_PRMS
 
     # Let's not forget to reset the dynamic parameters to not mess up the other tests
     reset_prms()
+
 
 def test_ceilochunk_basic():
     """ Test the basic methods of the CeiloChunk class. """
@@ -87,7 +89,7 @@ def test_ceilochunk_basic():
     # Create some fake data to get started
     # 1 very flat layer with no gaps
     mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
-                                   [{'alt':1000, 'alt_std': 10, 'sky_cov_frac': 1,
+                                   [{'alt': 1000, 'alt_std': 10, 'sky_cov_frac': 1,
                                      'period': 100, 'amplitude': 0}])
 
     # Instantiate a CeiloChunk entity ...
@@ -135,6 +137,7 @@ def test_ceilochunk_basic():
     assert chunk.metar_msg() == 'OVC009'
     assert chunk.metar_msg(which='groups') == 'OVC009'
 
+
 def test_ceilochunk_nocld():
     """ Test the methods of CeiloChunks when no clouds are seen in the interval. """
 
@@ -145,7 +148,7 @@ def test_ceilochunk_nocld():
     # Create some fake data to get started
     # 1 very flat layer with no gaps
     mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
-                                   [{'alt':1000, 'alt_std': 10, 'sky_cov_frac': 0,
+                                   [{'alt': 1000, 'alt_std': 10, 'sky_cov_frac': 0,
                                      'period': 100, 'amplitude': 0}])
 
     # Instantiate a CeiloChunk entity ...
@@ -159,6 +162,7 @@ def test_ceilochunk_nocld():
     # Assert the final METAR code is correct
     assert chunk.metar_msg() == 'NCD'
 
+
 def test_ceilochunk_2lay():
     """ Test the methods of CeiloChunks when 2 layers are seen in the interval. """
 
@@ -168,9 +172,9 @@ def test_ceilochunk_2lay():
 
     # Create some fake data to get started
     mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
-                                   [{'alt':1000, 'alt_std': 10, 'sky_cov_frac': 0.5,
+                                   [{'alt': 1000, 'alt_std': 10, 'sky_cov_frac': 0.5,
                                      'period': 100, 'amplitude': 0},
-                                    {'alt':2000, 'alt_std': 10, 'sky_cov_frac': 0.5,
+                                    {'alt': 2000, 'alt_std': 10, 'sky_cov_frac': 0.5,
                                        'period': 100, 'amplitude': 0}])
 
     # Instantiate a CeiloChunk entity ...
@@ -184,6 +188,7 @@ def test_ceilochunk_2lay():
     # Assert the final METAR code is correct
     assert chunk.metar_msg() == 'SCT009 SCT019'
 
+
 def test_layering_singlepts():
     """ Test the layering step when there is a single time steps. See #62 for the motivation. """
 
@@ -191,7 +196,7 @@ def test_layering_singlepts():
                                        ['dummy', -1, 4000, 2],
                                        ['dummy', -1, 4500, 3],
                                        ['dummy', -1, np.nan, 0]]),
-                            columns=['ceilo', 'dt', 'alt', 'type'])
+                             columns=['ceilo', 'dt', 'alt', 'type'])
 
     # Set the proper column types
     for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
@@ -208,4 +213,28 @@ def test_layering_singlepts():
     # Check that the GMM was never executed
     assert np.all(chunk.groups.loc[:, 'ncomp'] == -1)
     # Check that the resulting layers and groups are the same
-    assert np.all(chunk.groups.loc[:, 'code']==chunk.layers.loc[:, 'code'])
+    assert np.all(chunk.groups.loc[:, 'code'] == chunk.layers.loc[:, 'code'])
+
+
+def test_layering_singleval():
+    """ Test the layering step when there is a single altitude value. See #76 for details. """
+
+    data = np.array([np.ones(30), np.arange(0, 30, 1), np.ones(30)*170000, np.ones(30)])
+
+    mock_data = pd.DataFrame(data.T,
+                             columns=['ceilo', 'dt', 'alt', 'type'])
+
+    # Set the proper column types
+    for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
+        mock_data.loc[:, col] = mock_data.loc[:, col].astype(tpe)
+
+    # Instantiate a CeiloChunk entity ...
+    chunk = CeiloChunk(mock_data)
+
+    # Do the dance ...
+    chunk.find_slices()
+    chunk.find_groups()
+    chunk.find_layers()
+
+    # Check that the GMM was never executed
+    assert np.all(chunk.groups.loc[:, 'ncomp'] == -1)

--- a/test/ampycloud/test_dynamic.py
+++ b/test/ampycloud/test_dynamic.py
@@ -18,9 +18,9 @@ def test_dynamic_module():
     interactively if/when needed. """
 
     # Check that I can set a value and store it just fine.
-    val_orig = dynamic.AMPYCLOUD_PRMS.OKTA_LIM0
-    dynamic.AMPYCLOUD_PRMS.OKTA_LIM8 = -1
-    new_val = dynamic.AMPYCLOUD_PRMS.OKTA_LIM8
+    val_orig = dynamic.AMPYCLOUD_PRMS['OKTA_LIM0']
+    dynamic.AMPYCLOUD_PRMS['OKTA_LIM8'] = -1
+    new_val = dynamic.AMPYCLOUD_PRMS['OKTA_LIM8']
 
     assert 0 <= val_orig <= 100
     assert val_orig != new_val
@@ -28,18 +28,18 @@ def test_dynamic_module():
 
     # Check whether I can copy PRMS values and change these without altering the originals
     # (i.e do I need a deepcopy ?)
-    tmp = dynamic.AMPYCLOUD_PRMS.MPL_STYLE
-    assert tmp == dynamic.AMPYCLOUD_PRMS.MPL_STYLE
+    tmp = dynamic.AMPYCLOUD_PRMS['MPL_STYLE']
+    assert tmp == dynamic.AMPYCLOUD_PRMS['MPL_STYLE']
     tmp = 'bad'
-    assert dynamic.AMPYCLOUD_PRMS.MPL_STYLE != 'bad'
+    assert dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] != 'bad'
     assert tmp == 'bad'
 
     # Also test with new dictionnary keys, that seems to behave differently
     tmp = {}
-    tmp.update(dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_kwargs)
+    tmp.update(dynamic.AMPYCLOUD_PRMS['SLICING_PRMS']['dt_scale_kwargs'])
     tmp['new_entry'] = 'rubbish'
     assert 'new_entry' in tmp.keys()
-    assert 'new_entry' not in dynamic.AMPYCLOUD_PRMS.SLICING_PRMS.dt_scale_kwargs.keys()
+    assert 'new_entry' not in dynamic.AMPYCLOUD_PRMS['SLICING_PRMS']['dt_scale_kwargs'].keys()
 
     # Reset everything so as to not break havoc with the other tests
     reset_prms()

--- a/test/ampycloud/test_icao.py
+++ b/test/ampycloud/test_icao.py
@@ -11,6 +11,7 @@ Module content: tests for the icao module
 # Import from this package
 from ampycloud.icao import significant_cloud
 
+
 def test_significant_cloud():
     """ Test the significant_cloud function. """
 

--- a/test/ampycloud/test_layer.py
+++ b/test/ampycloud/test_layer.py
@@ -9,6 +9,7 @@ Module content: tests for the layer module
 """
 
 # Import from Python
+import warnings
 from pathlib import Path
 import pickle
 import pytest
@@ -141,3 +142,27 @@ def test_identical_pts():
 
     # I should only be getting a single layer
     assert out == 1
+
+    # Idem, but this time let's have only 2 distinct values
+    data = np.ones(30) * 24270.
+    data[-1] = 24271.
+
+    # The following code will raise warnings, which is fine. So let's hide them here.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out, _, _ = ncomp_from_gmm(data, scores='BIC', rescale_0_to_x=100, min_sep=200,
+                                   random_seed=45, delta_mul_gain=0.95, mode='delta')
+
+    assert out == 1
+
+    # And once more, but this time with far away points
+    data = np.ones(30) * 24270.
+    data[-1] = 10000.
+
+    # The following code will raise warnings, which is fine. So let's hide them here.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out, _, _ = ncomp_from_gmm(data, scores='BIC', rescale_0_to_x=100, min_sep=200,
+                                   random_seed=45, delta_mul_gain=0.95, mode='delta')
+
+    assert out == 2

--- a/test/ampycloud/test_scaler.py
+++ b/test/ampycloud/test_scaler.py
@@ -17,6 +17,7 @@ from ampycloud.scaler import shift_and_scale, minmax_scale, minrange2minmax, ste
 from ampycloud.scaler import convert_kwargs, apply_scaling
 from ampycloud.errors import AmpycloudError
 
+
 def test_shift_and_scale():
     """ Test the shift_and_scale routine. """
 
@@ -26,12 +27,13 @@ def test_shift_and_scale():
     assert shift_and_scale(np.ones(1), shift=0, mode='do') == 1
     assert np.all(shift_and_scale(np.array([1, 2]), scale=10, mode='do') == np.array([-0.1, 0]))
     assert shift_and_scale(np.zeros(1), shift=10, scale=10, mode='undo') == 10
-    assert np.all(shift_and_scale(np.array([7e5,7e5+1,7e5+2]), scale=10, mode='do') == \
-        np.array([-0.2, -0.1, 0]))
+    assert np.all(shift_and_scale(np.array([7e5, 7e5+1, 7e5+2]), scale=10, mode='do') ==
+                  np.array([-0.2, -0.1, 0]))
     tmp = np.array([1, 12, 3])
     # Check that this is indeed circular
-    assert np.all(shift_and_scale(shift_and_scale(tmp, scale=11, mode='do'),
-        scale=11, mode='undo', shift=np.nanmax(tmp)) == tmp)
+    assert np.all(shift_and_scale(shift_and_scale(
+        tmp, scale=11, mode='do'), scale=11, mode='undo', shift=np.nanmax(tmp)) == tmp)
+
 
 def test_minmax_scale():
     """ Test the minmax_scaling function, inculding the descaling mode. """
@@ -53,6 +55,7 @@ def test_minmax_scale():
     # Check NaNs stay NaNs
     assert np.all(np.isnan(deout[np.isnan(vals)]))
 
+
 def test_step_scale():
     """ Test the step scale function. """
 
@@ -70,16 +73,17 @@ def test_step_scale():
     # Check the continuity condition
     vals = np.arange(0, 25000, 10)
     out = step_scale(vals, steps=[3000, 7000, 10000, 14000], scales=[100, 500, 50, 1000, 10],
-                       mode='do')
+                     mode='do')
     # Basic check to make sure we are always increasing
     assert np.all(np.diff(out) > 0)
     # Check for gaps by looking at the slopes
     # If a slope value were to appear only once, it would be a gap.
-    assert np.all([np.count_nonzero(np.diff(out)==item) for item in np.unique(np.diff(out))])
+    assert np.all([np.count_nonzero(np.diff(out) == item) for item in np.unique(np.diff(out))])
     # Check I can undo the scaling
     deout = step_scale(out, steps=[3000, 7000, 10000, 14000], scales=[100, 500, 50, 1000, 10],
-                         mode='undo')
+                       mode='undo')
     assert np.all(np.round(deout, 1) == vals)
+
 
 def test_convert_kwargs():
     """ Test the convert_kwargs() function """
@@ -121,7 +125,7 @@ def test_apply_scaling():
     assert out == 0.5
 
     # Try with a min-range
-    din = np.array([1,5,9])
+    din = np.array([1, 5, 9])
     out = apply_scaling(din, fct='minmax-scale', min_range=10, mode='do')
     assert np.all(out == np.array([0.1, 0.5, 0.9]))
 

--- a/test/ampycloud/test_scientific_stability.py
+++ b/test/ampycloud/test_scientific_stability.py
@@ -18,13 +18,14 @@ import ampycloud
 from ampycloud import dynamic, reset_prms
 from ampycloud.plots import diagnostic
 
-def test_scientific_stability(mpls : str, do_sciplots: bool) -> None:
+
+def test_scientific_stability(mpls: str, do_sciplots: bool) -> None:
     """ Test the scientific stability of ampycloud. A series of reference cases is being processed,
     and the resulting METAR are compared with the expected outcome.
 
     Args:
-        mpls (str): False, or the value of MPL_STYLE requested by the user. This is set automatically
-            by a fixture that fetches the corresponding command line argument.
+        mpls (str): False, or the value of MPL_STYLE requested by the user. This is set
+            automatically by a fixture that fetches the corresponding command line argument.
             See conftest.py for details.
         do_sciplots (bool): True to make plots. This is set automatically
             by a fixture that fetches the corresponding command line argument.

--- a/test/ampycloud/test_scientific_stability.py
+++ b/test/ampycloud/test_scientific_stability.py
@@ -61,7 +61,7 @@ def test_scientific_stability(mpls : str, do_sciplots: bool) -> None:
 
         # Do I need to set a specific MSA ?
         if 'MSA' in ref_data_file.stem:
-            dynamic.AMPYCLOUD_PRMS.MSA = int(ref_data_file.stem.split('_')[3].split('.')[0][3:])
+            dynamic.AMPYCLOUD_PRMS['MSA'] = int(ref_data_file.stem.split('_')[3].split('.')[0][3:])
         else:
             # Make sure I use the default MSA
             reset_prms()
@@ -73,7 +73,7 @@ def test_scientific_stability(mpls : str, do_sciplots: bool) -> None:
         if do_sciplots:
             # Do I need to set a specific plotting style ?
             if mpls:
-                dynamic.AMPYCLOUD_PRMS.MPL_STYLE = mpls
+                dynamic.AMPYCLOUD_PRMS['MPL_STYLE'] = mpls
 
             # Create the plot
             diagnostic(chunk, upto='layers', ref_metar=ref_metar, ref_metar_origin='Should be',

--- a/test/ampycloud/test_wmo.py
+++ b/test/ampycloud/test_wmo.py
@@ -14,6 +14,7 @@ import numpy as np
 # Import from this package
 from ampycloud.wmo import perc2okta, alt2code
 
+
 def test_perc2okta():
     """ Test the frac2okta function. """
 
@@ -22,6 +23,7 @@ def test_perc2okta():
     assert np.all(perc2okta(2, lim0=3) == np.array([0]))
     assert np.all(perc2okta(np.array([10, 20, 35, 45, 60, 70, 85, 99]), lim8=98) ==
                   np.array([1, 2, 3, 4, 5, 6, 7, 8]))
+
 
 def test_alt2code():
     """ Test the alt2code function, inculding the descaling mode. """

--- a/test/ampycloud/utils/test_mocker.py
+++ b/test/ampycloud/utils/test_mocker.py
@@ -23,8 +23,7 @@ def test_mock_layers():
     n_ceilos = 1
     lookback_time = 1200
     hit_gap = 60
-    layer_prms =[{'alt':1000, 'alt_std': 100, 'sky_cov_frac': 1,
-                  'period': 100, 'amplitude': 0}]
+    layer_prms = [{'alt': 1000, 'alt_std': 100, 'sky_cov_frac': 1, 'period': 100, 'amplitude': 0}]
     out = mock_layers(n_ceilos, lookback_time, hit_gap, layer_prms)
 
     # Correct type ?
@@ -42,8 +41,7 @@ def test_mock_layers():
     n_ceilos = 2
     lookback_time = 1200
     hit_gap = 60
-    layer_prms =[{'alt':1000, 'alt_std': 100, 'sky_cov_frac': 0.5,
-                  'period': 100, 'amplitude': 0}]
+    layer_prms = [{'alt': 1000, 'alt_std': 100, 'sky_cov_frac': 0.5, 'period': 100, 'amplitude': 0}]
     out = mock_layers(n_ceilos, lookback_time, hit_gap, layer_prms)
 
     # Correct number of points ?
@@ -58,11 +56,10 @@ def test_mock_layers():
     n_ceilos = 2
     lookback_time = 1200
     hit_gap = 60
-    layer_prms =[{'alt':1000, 'alt_std': 100, 'sky_cov_frac': 1,
-                  'period': 100, 'amplitude': 0},
-                 {'alt':10000, 'alt_std': 200, 'sky_cov_frac': 1,
-                  'period': 100, 'amplitude': 0},
-                ]
+    layer_prms = [{'alt': 1000, 'alt_std': 100, 'sky_cov_frac': 1,
+                   'period': 100, 'amplitude': 0},
+                  {'alt': 10000, 'alt_std': 200, 'sky_cov_frac': 1,
+                   'period': 100, 'amplitude': 0}]
     out = mock_layers(n_ceilos, lookback_time, hit_gap, layer_prms)
 
     # Correct number of points ?
@@ -72,11 +69,10 @@ def test_mock_layers():
     n_ceilos = 2
     lookback_time = 1200
     hit_gap = 60
-    layer_prms =[{'alt':1000, 'alt_std': 100, 'sky_cov_frac': 1,
-                  'period': 100, 'amplitude': 0},
-                 {'alt':15000, 'alt_std': 200, 'sky_cov_frac': 1,
-                  'period': 100, 'amplitude': 0},
-                ]
+    layer_prms = [{'alt': 1000, 'alt_std': 100, 'sky_cov_frac': 1,
+                   'period': 100, 'amplitude': 0},
+                  {'alt': 15000, 'alt_std': 200, 'sky_cov_frac': 1,
+                   'period': 100, 'amplitude': 0}]
     out = mock_layers(n_ceilos, lookback_time, hit_gap, layer_prms)
 
     # Holes present ? There should be None, since we have a second layer complete

--- a/test/ampycloud/utils/test_performance.py
+++ b/test/ampycloud/utils/test_performance.py
@@ -11,6 +11,7 @@ Module content: tests for the utils.performance module
 # Import from ampycloud
 from ampycloud.utils.performance import get_speed_benchmark
 
+
 def test_speed_benchmark():
     """ This routine tests the get_speed_benchmark function. """
 

--- a/test/ampycloud/utils/test_utils.py
+++ b/test/ampycloud/utils/test_utils.py
@@ -9,6 +9,7 @@ Module content: tests for the utils.utils module
 """
 
 # Import form Python
+import warnings
 from pytest import raises, warns
 import numpy as np
 import pandas as pd
@@ -22,9 +23,9 @@ from ampycloud import hardcoded
 def test_check_data_consistency():
     """ This routine tests the check_data_consistency method. """
 
-    # Uncomment the line below once pytst 7.0 can be pip-installed
-    #with pytest.does_not_warn():
-    if True:
+    # The following should not trigger any warning... let's make sure of that.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         out = check_data_consistency(canonical_demo_data())
 
         # Make sure the canonical demo data is perfectly compatible with the ampycloud requirements

--- a/test/ampycloud/utils/test_utils.py
+++ b/test/ampycloud/utils/test_utils.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 # Import from ampycloud
-from ampycloud.utils.utils import check_data_consistency, tmp_seed
+from ampycloud.utils.utils import check_data_consistency, tmp_seed, adjust_nested_dict
 from ampycloud.utils.mocker import canonical_demo_data
 from ampycloud.errors import AmpycloudError, AmpycloudWarning
 from ampycloud import hardcoded
@@ -88,7 +88,6 @@ def test_check_data_consistency():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
 
-
 def test_tmp_seed():
     """ This routine tests the tmp_seed. """
 
@@ -116,3 +115,22 @@ def test_tmp_seed():
 
     # Can I recover the original seed ?
     assert np.all(a43 == np.random.random(100))
+
+def test_adjust_nested_dict():
+    """ This routine tests the adjust_nested_dict function. """
+
+    ref_dict = {'a':0, 'b':{1:{0}}}
+    new_dict = {'a':1}
+
+    out = adjust_nested_dict(ref_dict, new_dict)
+    assert out['a'] == 1
+    assert out['b'] == ref_dict['b']
+
+    # Setting a non-pre-existing key should raise an Warning
+    with warns(AmpycloudWarning):
+        out = adjust_nested_dict(ref_dict, {'b': {'d':{0}}})
+        assert out == ref_dict
+
+    new_dict = {'a':[1, 2, 3], 'b':{1:{2}}}
+    out = adjust_nested_dict(ref_dict, new_dict)
+    assert out == new_dict

--- a/test/ampycloud/utils/test_utils.py
+++ b/test/ampycloud/utils/test_utils.py
@@ -20,6 +20,7 @@ from ampycloud.utils.mocker import canonical_demo_data
 from ampycloud.errors import AmpycloudError, AmpycloudWarning
 from ampycloud import hardcoded
 
+
 def test_check_data_consistency():
     """ This routine tests the check_data_consistency method. """
 
@@ -40,7 +41,7 @@ def test_check_data_consistency():
         # Missing column
         data = pd.DataFrame(np.array([['a', 1, 1]]), columns=['ceilo', 'alt', 'type'])
         for col in ['ceilo', 'alt', 'type']:
-            data.loc[:, col] = data.loc[:,col].astype(hardcoded.REQ_DATA_COLS[col])
+            data.loc[:, col] = data.loc[:, col].astype(hardcoded.REQ_DATA_COLS[col])
         check_data_consistency(data)
     with warns(AmpycloudWarning):
         # Bad data type
@@ -89,6 +90,7 @@ def test_check_data_consistency():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
 
+
 def test_tmp_seed():
     """ This routine tests the tmp_seed. """
 
@@ -108,8 +110,8 @@ def test_tmp_seed():
     assert np.all(a == a42)
 
     # Now, actually check the function I am interested in.
-    np.random.seed(43) # Set a seed
-    with tmp_seed(42): # Temporarily set anopther one
+    np.random.seed(43)  # Set a seed
+    with tmp_seed(42):  # Temporarily set anopther one
         assert np.all(a == np.random.random(100))
         assert np.all(b == np.random.random(10))
         assert np.all(c == np.random.random(1))
@@ -117,11 +119,12 @@ def test_tmp_seed():
     # Can I recover the original seed ?
     assert np.all(a43 == np.random.random(100))
 
+
 def test_adjust_nested_dict():
     """ This routine tests the adjust_nested_dict function. """
 
-    ref_dict = {'a':0, 'b':{1:{0}}}
-    new_dict = {'a':1}
+    ref_dict = {'a': 0, 'b': {1: {0}}}
+    new_dict = {'a': 1}
 
     out = adjust_nested_dict(ref_dict, new_dict)
     assert out['a'] == 1
@@ -129,9 +132,9 @@ def test_adjust_nested_dict():
 
     # Setting a non-pre-existing key should raise an Warning
     with warns(AmpycloudWarning):
-        out = adjust_nested_dict(ref_dict, {'b': {'d':{0}}})
+        out = adjust_nested_dict(ref_dict, {'b': {'d': {0}}})
         assert out == ref_dict
 
-    new_dict = {'a':[1, 2, 3], 'b':{1:{2}}}
+    new_dict = {'a': [1, 2, 3], 'b': {1: {2}}}
     out = adjust_nested_dict(ref_dict, new_dict)
     assert out == new_dict


### PR DESCRIPTION
**Description:**

This PR drops the use of ``yaconfigobject`` in favor of ``ruamel.yamel``, and makes ampycloud thread-safe by allowing users to feed parameters directly to the ``run`` function (and storing a copy of the parameter dictionary as an instance variable). The docs has been updated accordingly.

This PR also fixes a problem with the layering step when all the altitudes are **exactly** the same.

This PR also introduces/fixes a few more minor things, including:
- a new CI/CD action to monitor the processing speed of the code
- a few additional tests to check that no warnings are raised in specific occasions
- a minimum number of 30 valid points are now required to run the GMM (layering step)
- a general cleanup of the code to remove the majority of flake8 style errors
- the available  CPU count, when calling the `ampycloud_speed_test` entry point

**Error(s) fixed:**

Fixes #71 , fixes #25, fixes #75, fixes #61, fixes #36, fixes #69, fixes #76.

**Checklists**:
- [x] New code includes dedicated tests.
- [x] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [x] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [x] Copyright years in module docstrings have been updated.
