### PR TITLE
Develop fol

### DIFF
--- a/examples/demo_minimum_separation.py
+++ b/examples/demo_minimum_separation.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+import ampycloud
+from ampycloud.utils import mocker
+from ampycloud.plots import diagnostic
+import sys
+
+# Generate the demo dataset for ampycloud to test the minimum separation parameter.
+# Your data should have *exactly* this structure
+
+## EXAMPLE 1
+n_ceilos = 4
+lookback_time = 1200
+rate = 30
+mock_data = mocker.mock_layers(n_ceilos, lookback_time, rate,
+                                   [{'alt': 500, 'alt_std': 30, 'sky_cov_frac': 0.5,
+                                     'period': 100, 'amplitude': 20},
+                                     {'alt': 700, 'alt_std': 30, 'sky_cov_frac': 0.5,
+                                     'period': 100, 'amplitude': 20},
+                                     {'alt': 1400, 'alt_std': 30, 'sky_cov_frac': 0.5,
+                                     'period': 100, 'amplitude': 20},
+                                     {'alt': 1600, 'alt_std': 30, 'sky_cov_frac': 0.5,
+                                     'period': 100, 'amplitude': 20}])
+
+# Run the ampycloud algorithm on it, setting the MSA to 10'000 ft
+chunk = ampycloud.run(mock_data, geoloc='Mock data', ref_dt=datetime.now())
+
+# Get the resulting METAR message
+print(chunk.metar_msg())
+
+# Display the full information available for the layers found
+print(chunk.layers)
+
+# And for the most motivated, plot the diagnostic diagram
+diagnostic(chunk, upto='layers', show=True, save_stem='ampycloud_demo_minsep', save_fmts=['png'])

--- a/src/ampycloud/core.py
+++ b/src/ampycloud/core.py
@@ -219,6 +219,10 @@ def run(data: pd.DataFrame, prms: dict = None, geoloc: str = None,
             # Or to adjust some other algorithm parameter:
             prms = {'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 300}}}
 
+            # Beware not to overwrite parameters! DO NOT write it as:
+            prms = {'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 300}}, 'GROUPING_PRMS':{'algo': 'agglomerative'}}
+            # but write as:
+            prms = {'GROUPING_PRMS':{'dt_scale_kwargs':{'scale': 300}, 'algo': 'agglomerative'}}
 
     The :py:class:`.data.CeiloChunk` instance returned by this function contains all the information
     associated to the ampycloud algorithm, inclduing the raw data and slicing/grouping/layering

--- a/src/ampycloud/data.py
+++ b/src/ampycloud/data.py
@@ -636,11 +636,14 @@ class CeiloChunk(AbstractChunk):
             # Reshape the array in anticipation of the GMM routine ...
             gro_alts = gro_alts.reshape(-1, 1)
 
-            # Let's also get the overall group base alt
-            if self.groups.at[ind, 'alt_base'] > 10000:
-                min_sep = self.prms['LAYERING_PRMS']['min_sep_high']
-            else:
-                min_sep = self.prms['LAYERING_PRMS']['min_sep_low']
+            # Get minimum separation based on group base alt
+            min_sep_steps = self.prms['LAYERING_PRMS']['min_sep_kwargs']['steps']
+            min_sep_vals = self.prms['LAYERING_PRMS']['min_sep_kwargs']['separ']
+            if len(min_sep_steps) != len(min_sep_vals)-1:
+                raise AmpycloudError(f'Ouch ! len({min_sep_steps}) should be equal to len({min_sep_vals})-1.')
+
+            idx_sep = utils.index_between(min_sep_steps, self.groups.at[ind, 'alt_base'])
+            min_sep = min_sep_vals[idx_sep]
             logger.info('Group base alt: %.1f', self.groups.at[ind, 'alt_base'])
             logger.info('min_sep value: %.1f', min_sep)
 

--- a/src/ampycloud/data.py
+++ b/src/ampycloud/data.py
@@ -469,7 +469,8 @@ class CeiloChunk(AbstractChunk):
             pass
 
         # Finally, let's metarize these slices !
-        self.metarize(which='slices', lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
+        self.metarize(which='slices', base_frac=self.prms['LAYER_BASE_FRAC'],
+                    lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
 
     @log_func_call(logger)
     def find_groups(self) -> None:
@@ -576,7 +577,8 @@ class CeiloChunk(AbstractChunk):
         self.data.loc[to_fill, 'group_id'] = self.data.loc[to_fill, 'slice_id']
 
         # Finally, let's metarize these !
-        self.metarize(which='groups', lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
+        self.metarize(which='groups', base_frac=self.prms['LAYER_BASE_FRAC'],
+                    lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
 
     @log_func_call(logger)
     def find_layers(self) -> None:
@@ -662,7 +664,8 @@ class CeiloChunk(AbstractChunk):
         self.data.loc[to_fill, 'layer_id'] = self.data.loc[to_fill, 'group_id']
 
         # Finally, let's metarize these !
-        self.metarize(which='layers', lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
+        self.metarize(which='layers', base_frac=self.prms['LAYER_BASE_FRAC'],
+                    lim0=self.prms['OKTA_LIM0'], lim8=self.prms['OKTA_LIM8'])
 
     @property
     def n_slices(self) -> Union[None, int]:

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -70,32 +70,34 @@ GROUPING_PRMS:
         affinity: manhattan
     # Time scaling mode
     dt_scale_mode: shift-and-scale
-    # Time scaling parameters
+    # Time scaling parameters (in min)
     dt_scale_kwargs:
         scale: 180
     # Altitude scaling mode
     alt_scale_mode: step-scale
-    # Altitude scaling parameters
+    # Altitude scaling parameters (in ft)
     alt_scale_kwargs:
         steps: [8000, 14000]
         scales: [100, 500, 1000]
-    # Distance from the mean altitude (in std) below which two slices are considered "overlapping"
+    # Distance from the mean altitude (in std in scaled units) below which two slices are considered "overlapping"
     overlap: 2.0
 
 # Layering parameters
 LAYERING_PRMS:
     # Minimum okta value below which cluster splitting is not attempted
     min_okta_to_split: 2
-    # Minimum separation (in ft) between the mean altitude of identified layers inside groups
-    # with a base altitude <=10'000ft. Any layers separated by less than this value will not be
-    # split. Any value < than 5 times the vertical resolution of the data will raise a warning, as
+    # Minimum layer separation parameters (in ft).
+    # Any number of values is allowed as long as len(steps) = len(separ)-1
+    # Minimum separation between the mean altitude of identified layers inside groups.
+    # Any layers separated by less than the separ value within the steps range will not be split.
+    # Any separ value < than 5 times the vertical resolution of the data will raise a warning, as
     # it may lead to an over-layering of groups. For the ampycloud METAR messages to be consistent
     # with the ICAO rules of layer selection, this should be >=100 ft.
-    min_sep_low: 150
-    # Same as min_sep_low, but for layers identified in groups with a base height >10'000 ft. For
-    # the ampycloud METAR messages to be consistent with the ICAO rules of layer selection, this
-    # should be >=1000 ft.
-    min_sep_high: 1000
+    # For the ampycloud METAR messages to be consistent with the ICAO rules of layer selection,
+    # the minimum separ value should be >=1000 ft above 10'000 ft.
+    min_sep_kwargs:
+        steps: [2000, 5000]
+        separ: [1000, 500, 1000]
     # Gaussian Mixture Model parameters
     gmm_kwargs:
         # Whether to use 'BIC' or 'AIC' scores to decide which model is "best".

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -19,8 +19,14 @@ OKTA_LIM0: 2
 # Min sky coverage (in %) down to which the coverage is considered full.
 OKTA_LIM8: 98
 
-# Fraction of smallest layer points to median to compute the layer altitude for the METAR
-LAYER_BASE_FRAC: 0.1
+# Percentile (in %) of the cloud hit heights (sorted from smallest to highest)
+# to compute the layer altitude for the METAR
+LAYER_BASE_PERC: 10
+
+# Percentile (in %) of the cloud hit times to compute the layer altitude for the METAR
+# 100%: it uses all the hits during the period
+# 50%: it uses only the last 50% of hits during the period
+LAYER_LOOKBACK_PERC: 100
 
 # Minimum Sector Altitude, in ft. No cloud layers with a base above this value will be reported
 # in the ampycloud METAR messages. Set it to null for no limit.

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -21,7 +21,7 @@ OKTA_LIM8: 98
 
 # Percentile (in %) of the cloud hit heights (sorted from smallest to highest)
 # to compute the layer altitude for the METAR
-LAYER_BASE_PERC: 10
+LAYER_BASE_PERC: 5
 
 # Percentile (in %) of the cloud hit times to compute the layer altitude for the METAR
 # 100%: it uses all the hits during the period

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -57,6 +57,10 @@ SLICING_PRMS:
     # Altitude scaling parameters
     alt_scale_kwargs:
         min_range: 1000
+    # Minimum layer separation parameters (in ft). See more details below.
+    min_sep_kwargs:
+        steps: [1000, 5000]
+        separ: [150, 300, 1000]
 
 # Clustering parameters
 GROUPING_PRMS:
@@ -81,23 +85,15 @@ GROUPING_PRMS:
         scales: [100, 500, 1000]
     # Distance from the mean altitude (in std in scaled units) below which two slices are considered "overlapping"
     overlap: 2.0
+    # Minimum layer separation parameters (in ft). See more details below.
+    min_sep_kwargs:
+        steps: [1000, 5000]
+        separ: [150, 300, 1000]
 
 # Layering parameters
 LAYERING_PRMS:
     # Minimum okta value below which cluster splitting is not attempted
     min_okta_to_split: 2
-    # Minimum layer separation parameters (in ft).
-    # Any number of values is allowed as long as len(steps) = len(separ)-1
-    # Minimum separation between the mean altitude of identified layers inside groups.
-    # Any layers separated by less than the separ value within the steps range will not be split.
-    # Any separ value < than 5 times the vertical resolution of the data will raise a warning, as
-    # it may lead to an over-layering of groups. For the ampycloud METAR messages to be consistent
-    # with the ICAO rules of layer selection, this should be >=100 ft.
-    # For the ampycloud METAR messages to be consistent with the ICAO rules of layer selection,
-    # the minimum separ value should be >=1000 ft above 10'000 ft.
-    min_sep_kwargs:
-        steps: [2000, 5000]
-        separ: [150, 500, 1000]
     # Gaussian Mixture Model parameters
     gmm_kwargs:
         # Whether to use 'BIC' or 'AIC' scores to decide which model is "best".
@@ -115,3 +111,20 @@ LAYERING_PRMS:
         delta_mul_gain: 0.95
         # If set, rescale each group between 0 and this value before looking for layers using gmm.
         rescale_0_to_x: 100
+    # Minimum layer separation parameters (in ft). See more details below.
+    min_sep_kwargs:
+        steps: [1000, 5000]
+        separ: [150, 300, 1000]
+
+# Minimum layer separation parameters (min_sep_kwargs, in ft).
+# Minimum separation between the altitude of identified layers inside slices/groups/layers.
+# Any layers separated by more than the separ value within the steps range will be remerged.
+# Any separ value < than 5 times the vertical resolution of the data will raise a warning, as
+# it may lead to an over-layering of groups (especially in the layering step). 
+# For the ampycloud METAR to be consistent with the ICAO rules of layer selection, this should be >=100 ft.
+# For the ampycloud METAR to be consistent with the ICAO rules of layer selection,
+# the minimum separ value should be >=1000 ft above 10'000 ft.
+# Possible values of steps and separ:
+#   Any number of values is allowed as long as len(steps) = len(separ)-1
+#   Set the value 'null' to turn off this option.
+

--- a/src/ampycloud/prms/ampycloud_default_prms.yml
+++ b/src/ampycloud/prms/ampycloud_default_prms.yml
@@ -97,7 +97,7 @@ LAYERING_PRMS:
     # the minimum separ value should be >=1000 ft above 10'000 ft.
     min_sep_kwargs:
         steps: [2000, 5000]
-        separ: [1000, 500, 1000]
+        separ: [150, 500, 1000]
     # Gaussian Mixture Model parameters
     gmm_kwargs:
         # Whether to use 'BIC' or 'AIC' scores to decide which model is "best".

--- a/src/ampycloud/utils/utils.py
+++ b/src/ampycloud/utils/utils.py
@@ -15,6 +15,7 @@ import contextlib
 import copy
 import numpy as np
 import pandas as pd
+from typing import Union
 
 # Import from this package
 from ..errors import AmpycloudError, AmpycloudWarning
@@ -238,3 +239,42 @@ def adjust_nested_dict(ref_dict: dict, new_dict: dict, lvls: list = None) -> dic
             ref_dict[key] = item
 
     return ref_dict
+
+def index_between(limits: list, value: Union[int,float]) -> int:
+    """ Return the index of value in the list limits (between limits[i-1] and limits[i]).
+
+    Args:
+        limits (list): list of limit values, e.g. the grouping steps
+        value (int|float): value to locate.
+
+    Returns:
+        idx (int): index of the value position:
+            0: value is lower than the lowest value of limits
+            len(limits): value is higher than the highest value of limits
+            other: limits[i] <= value < limits[i+1]
+    """
+    if len(limits) == 0:
+        raise AmpycloudError("limits must be a non-empty list.")
+
+    if not isinstance(limits, list):
+        raise AmpycloudError(f"limits should be of type list, but is of type {type(limits)}")
+
+    if len(np.unique(np.array(limits))) != len(np.array(limits)):
+        raise AmpycloudError(f"limits cannot contain duplicate values..")
+
+    if limits != sorted(limits):
+        warnings.warn(f'Huh ! List {limits} shuold be sorted beforehand.',
+                          AmpycloudWarning)
+        logger.warning('Sorting list... but may give unexpected behaviour.')
+        limits = sorted(limits)
+
+    n_steps = len(limits)
+    sep_bool = np.array(limits) > value
+    if np.sum(sep_bool) == n_steps:
+        idx = 0
+    elif np.sum(sep_bool) == 0:
+        idx = n_steps
+    else:
+        idx = sep_bool.argmax()
+
+    return idx

--- a/test/ampycloud/utils/test_utils.py
+++ b/test/ampycloud/utils/test_utils.py
@@ -36,21 +36,25 @@ def test_check_data_consistency():
     with raises(AmpycloudError):
         # Empty DataFrame
         data = pd.DataFrame(columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         check_data_consistency(data)
     with raises(AmpycloudError):
         # Missing column
         data = pd.DataFrame(np.array([['a', 1, 1]]), columns=['ceilo', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for col in ['ceilo', 'alt', 'type']:
             data.loc[:, col] = data.loc[:, col].astype(hardcoded.REQ_DATA_COLS[col])
         check_data_consistency(data)
     with warns(AmpycloudWarning):
         # Bad data type
         data = pd.DataFrame(np.array([['a', 0, 1, 1]]), columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         check_data_consistency(data)
     with warns(AmpycloudWarning):
         # Extra key
         data = pd.DataFrame(np.array([['a', 0, 1, 1, 99]]),
                             columns=['ceilo', 'dt', 'alt', 'type', 'extra'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
@@ -58,6 +62,7 @@ def test_check_data_consistency():
         # Negative alts
         data = pd.DataFrame(np.array([['a', 0, -1, 1]]),
                             columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
@@ -65,6 +70,7 @@ def test_check_data_consistency():
         # Type 0 should be NaN
         data = pd.DataFrame(np.array([['a', 0, 1, 0]]),
                             columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
@@ -72,6 +78,7 @@ def test_check_data_consistency():
         # Type 1 should not be NaN
         data = pd.DataFrame(np.array([['a', 0, np.nan, 1]]),
                             columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
@@ -79,6 +86,7 @@ def test_check_data_consistency():
         # Missing type 1 pts
         data = pd.DataFrame(np.array([['a', 0, 1, 2]]),
                             columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)
@@ -86,6 +94,7 @@ def test_check_data_consistency():
         # Missing type 2 pts
         data = pd.DataFrame(np.array([['a', 0, 1, 3]]),
                             columns=['ceilo', 'dt', 'alt', 'type'])
+        data['ceilo'] = data['ceilo'].astype(pd.StringDtype())
         for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
             data.loc[:, col] = data.loc[:, col].astype(tpe)
         check_data_consistency(data)

--- a/test/ampycloud/utils/test_utils.py
+++ b/test/ampycloud/utils/test_utils.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 
 # Import from ampycloud
-from ampycloud.utils.utils import check_data_consistency, tmp_seed, adjust_nested_dict
+from ampycloud.utils.utils import check_data_consistency, tmp_seed, adjust_nested_dict, index_between
 from ampycloud.utils.mocker import canonical_demo_data
 from ampycloud.errors import AmpycloudError, AmpycloudWarning
 from ampycloud import hardcoded
@@ -147,3 +147,16 @@ def test_adjust_nested_dict():
     new_dict = {'a': [1, 2, 3], 'b': {1: {2}}}
     out = adjust_nested_dict(ref_dict, new_dict)
     assert out == new_dict
+
+def test_index_between():
+    """ This routine tests the function index_between. """
+
+    assert index_between([0,2],-1) == 0
+    assert index_between([0,2],3) == 2
+    assert index_between([0,2],1) == 1
+    assert index_between([1],-1) == 0
+    assert index_between([1],2) == 1
+    with raises(AmpycloudError):
+        assert index_between(np.array([0,2]),2)
+        assert index_between([],2)
+        assert index_between([1,2,2],2)


### PR DESCRIPTION
**Description:**

This PR solves a small bug, simplifies one calculation and adds two extensions to the algorithm:

- **Bug**: the LAYER_BASE_FRAC was not passed to the metarize method, so changing this parameter had no effect. 
- **Simplification**: the parameter LAYER_BASE_FRAC was renamed LAYER_BASE_PERC, but has now a different behaviour. Instead of computing the layer height as the median of the lowest percentage of cloud heights, it is sopmuted as a given percentile. You obtain the same behaviour as before by setting `LAYER_BASE_PERC = LAYER_BASE_FRAC*100/2`
- **Extension 1**: calculation of cloud layer height as percentile of the most recent cloud hits instead of the whole time interval. This allows reducing the height underestimation of layers whose height is gradually increasing.
- **Extension 2**: merging of too close layers was introduced also in the grouping and slicing steps (not only the layering). In addition, the minimum separation parameters can be specified according to height ranges. This reduces the amount of algorithm overlayering, which was sometimes producing two FEW layers rather than one BKN layer (especially at high heights).

This PR is not yet finished: extension 2 does not work yet as specified and tests need to be added. Also, some tests did not pass, e.g. due to moving out from the layering step the AmpycloudWarning for too close layers.

**Error(s) fixed:**

Please tag them using `#`, e.g. `Fixed #42`.

**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [ ] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
