### PR TITLE
Fix #119

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
  - [regDaniel, 2024-04-09] Add flag for clouds above (MSA + MSA_HIT_BUFFER) and allow for NSC in METAR message.
  - [fpavogt, 2024-03-26] Add option to reset only a single parameter.
 ### Fixed:
+ - [fpavogt, 2024-04-17] Fix #119
  - [regDaniel, 2024-04-09] Minor adaptions to better comply with PEP standards.
  - [fpavogt, 2024-03-26] Use "height" in "ft aal" throughout.
 ### Changed:

--- a/src/ampycloud/layer.py
+++ b/src/ampycloud/layer.py
@@ -221,9 +221,10 @@ def ncomp_from_gmm(vals: np.ndarray,
     models = {}
 
     # Run the Gaussian Mixture fit for all cases ... should we do anything more fancy here ?
-    with utils.tmp_seed(random_seed):
-        for n_val in ncomp:
-            models[n_val] = GaussianMixture(n_val, covariance_type='spherical').fit(vals)
+    #with utils.tmp_seed(random_seed):
+    for n_val in ncomp:
+        models[n_val] = GaussianMixture(n_val, covariance_type='spherical',
+                                        random_state=random_seed).fit(vals)
 
     # Extract the AICS and BICS scores
     if scores == 'AIC':
@@ -233,14 +234,24 @@ def ncomp_from_gmm(vals: np.ndarray,
     else:
         raise AmpycloudError(f'Unknown scores: {scores}')
 
+    # Fix #119: at times, not all sub-layers may be populated by GaussianMixture.
+    # To avoid problems down the line, we shall boost the abics score of such cases to make sure
+    # they are NOT taken as the best model
+    for (n_id, n_val) in enumerate(ncomp):
+        if (n_eff := len(np.unique(models[n_val].predict(vals)))) < n_val:
+            logger.warning(' %i out of %i sub-layers populated by GaussianMixture(%i) - see #119. '
+                           'Ruling out %i components as a possibility.',
+                           n_eff, n_val, n_val, n_val)
+            abics[n_id] = max(abics) + 1  # The larger the abics score, the worst the fit.
+
     # Get the interesting information out
     best_model_ind = best_gmm(abics, **kwargs)
     best_ncomp = ncomp[best_model_ind]
     best_ids = models[ncomp[best_model_ind]].predict(vals)
 
-    logger.debug('%s scores: %s', scores, abics)
-    logger.debug('best_model_ind (raw): %i', best_model_ind)
-    logger.debug('best_ncomp (raw): %i', best_ncomp)
+    logger.debug(' %s scores: %s', scores, abics)
+    logger.debug(' best_model_ind (raw): %i', best_model_ind)
+    logger.debug(' best_ncomp (raw): %i', best_ncomp)
 
     # If I found only one component, I can stop here
     if best_ncomp == 1:

--- a/src/ampycloud/layer.py
+++ b/src/ampycloud/layer.py
@@ -221,7 +221,6 @@ def ncomp_from_gmm(vals: np.ndarray,
     models = {}
 
     # Run the Gaussian Mixture fit for all cases ... should we do anything more fancy here ?
-    #with utils.tmp_seed(random_seed):
     for n_val in ncomp:
         models[n_val] = GaussianMixture(n_val, covariance_type='spherical',
                                         random_state=random_seed).fit(vals)

--- a/src/ampycloud/utils/utils.py
+++ b/src/ampycloud/utils/utils.py
@@ -292,7 +292,7 @@ def calc_base_height(vals: npt.ArrayLike,
     n_latest_elements = vals[- int(len(vals) * lookback_perc / 100):]
     if len(n_latest_elements) == 0:
         raise AmpycloudError(
-            'Cloud base calculation got an empty array.'
-            f'Maybe check lookback percentage (is set to {lookback_perc})'
+            'Cloud base calculation got an empty array. '
+            f'Maybe check lookback percentage ? (currently set to {lookback_perc})'
         )
     return np.percentile(n_latest_elements, height_perc)


### PR DESCRIPTION
**Description:**

This PR fixes #119. It does so by:
 a) correctly feeding a `random_seed` to the `GaussianMixture()` call, and 
 b) boosts the `abics` score of any option fo which not all the sub-layers are populated as a result of the `.predict()` call.

**Error(s) fixed:**

Fixes #119.

**Checklists**:
- [ ] New code includes dedicated tests.
- [x] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [x] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
