### PR TITLE
Add rogue point to mock dataset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
  - [regDaniel, 2024-04-09] Minor adaptions to better comply with PEP standards.
  - [fpavogt, 2024-03-26] Use "height" in "ft aal" throughout.
 ### Changed:
+ - [fpavogt, 2024-04-28] Add a rogue point to the mock example.
  - [fpavogt, 2024-03-25] Set the fluffiness boost to 2 (fixes #123).
  - [fpavogt, 2024-03-23] Changed default mock dataset to be 900s long (instead of 2400s).
 

--- a/src/ampycloud/utils/mocker.py
+++ b/src/ampycloud/utils/mocker.py
@@ -210,4 +210,8 @@ def canonical_demo_data() -> DataFrame:
         # Actually generate the mock data
         out: DataFrame = mock_layers(n_ceilos, lookback_time, hit_gap, lyrs)
 
+    # Add a rogue hit, to illustrate the fact that layers that fall below Theta_0 are not
+    # reported in the diagnostic diagram, but remain "counted".
+    out.loc[len(out)] = [-800, 3100, 1, 1]
+
     return out

--- a/src/ampycloud/utils/mocker.py
+++ b/src/ampycloud/utils/mocker.py
@@ -214,4 +214,8 @@ def canonical_demo_data() -> DataFrame:
     # reported in the diagnostic diagram, but remain "counted".
     out.loc[len(out)] = [-800, 3100, 1, 1]
 
+    # Fix the dtypes
+    for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
+        out[col] = out[col].astype(tpe)
+
     return out

--- a/src/ampycloud/utils/mocker.py
+++ b/src/ampycloud/utils/mocker.py
@@ -212,10 +212,8 @@ def canonical_demo_data() -> DataFrame:
 
     # Add a rogue hit, to illustrate the fact that layers that fall below Theta_0 are not
     # reported in the diagnostic diagram, but remain "counted".
-    out.loc[len(out)] = [-800, 3100, 1, 1]
-
-    # Fix the dtypes
-    for (col, tpe) in hardcoded.REQ_DATA_COLS.items():
-        out[col] = out[col].astype(tpe)
+    # To avoid confusing users, we will replace an existing hit: pick one closest to -800s.
+    swap_id = (abs(out[(out['ceilo'] == '1')*(out['type'] == 2)]['dt']-800)).argmin()
+    out.at[swap_id, 'height'] = 3100.0
 
     return out


### PR DESCRIPTION
**Description:**

Following the suggestion by @loforest, this PR adds an additional rogue point to the mock dataset to better illustrate the ampycloud diagnostic plot behavior with layers that have less than Theta_0 points in them.

**Error(s) fixed:**


**Checklists**:
- [ ] New code includes dedicated tests.
- [x] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [x] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
