### PR TITLE
Allow to trigger the weekly tests manually

### DIFF
--- a/.github/workflows/CI_pytest_weekly.yml
+++ b/.github/workflows/CI_pytest_weekly.yml
@@ -10,6 +10,7 @@
 name: CI_pytest_weekly
 
 on:
+  workflow_dispatch:  # Allow to trigger the weekly tests manually
   schedule:
     - cron: '43 21 * * 1,4'  # Run at 21:43 UTC every Monday and Thursday
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [v2.0.0]
 ### Added:
+ - [fpavogt, 2024-06-26] Add ability to trigger weekly tests manually.
  - [fpavogt, 2024-04-16] Improve input data consistency check (fix #116).
  - [regDaniel, 2024-04-09] Add flag for clouds above (MSA + MSA_HIT_BUFFER) and allow for NSC in METAR message.
  - [fpavogt, 2024-03-26] Add option to reset only a single parameter.


### PR DESCRIPTION
**Description:**

This small PR allows to trigger the weekly tests Action manually. This is to avoid having to wait a few days to correct the associated tag when one fixes a problem in the code.

**Error(s) fixed:**

**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with the 3-Clause BSD license.
- [x] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
