### PR TITLE
Fix manual trigger of automated tests

### DIFF
--- a/.github/workflows/CI_pytest_weekly.yml
+++ b/.github/workflows/CI_pytest_weekly.yml
@@ -23,15 +23,22 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    # Checkout the repo
+    # Checkout the master branch if this is a scheduled test
     # The idea for this Action is to spot issues with new dependency versions as soon as they
     # are released (and not when we decide to update ampycloud).
-    - name: Checkout current repository
+    - name: Checkout current repository (master branch)
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       uses: actions/checkout@v4
       with:
         repository: MeteoSwiss/ampycloud
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-            ref: master  # If run on schedule, use the master branch.
+        ref: master
+
+    # Alternatively, checkout whichever branch was selected by the user upon the manual trigger.
+    - name: Checkout current repository (custom branch)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v4
+      with:
+        repository: MeteoSwiss/ampycloud
 
     # Setup python
     - name: Set up Python

--- a/.github/workflows/CI_pytest_weekly.yml
+++ b/.github/workflows/CI_pytest_weekly.yml
@@ -27,7 +27,7 @@ jobs:
     # The idea for this Action is to spot issues with new dependency versions as soon as they
     # are released (and not when we decide to update ampycloud).
     - name: Checkout current repository (master branch)
-      if: ${{ github.event_name != 'workflow_dispatch' }}
+      if: ${{ github.event_name == 'schedule' }}
       uses: actions/checkout@v4
       with:
         repository: MeteoSwiss/ampycloud

--- a/.github/workflows/CI_pytest_weekly.yml
+++ b/.github/workflows/CI_pytest_weekly.yml
@@ -23,14 +23,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    # Checkout the master branch from the repository
+    # Checkout the repo
     # The idea for this Action is to spot issues with new dependency versions as soon as they
     # are released (and not when we decide to update ampycloud).
     - name: Checkout current repository
       uses: actions/checkout@v4
       with:
         repository: MeteoSwiss/ampycloud
-        ref: master
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+            ref: master  # If run on schedule, use the master branch.
 
     # Setup python
     - name: Set up Python


### PR DESCRIPTION
**Description:**

This PR fixes (hopefully) the manual branch selection of the automated check Action.

Specifically, the Action forces the use of the `master` branch for the scheduled checks. But we want to be able to freely select the branch when triggering it manually.

**Error(s) fixed:**

**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code has been linted.
- [ ] New code follows the project's style.
- [ ] New code is compatible with the 3-Clause BSD license.
- [ ] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
- [ ] Copyright years in module docstrings have been updated.
